### PR TITLE
Fix inferencing on a system with a GPU

### DIFF
--- a/model.py
+++ b/model.py
@@ -161,11 +161,11 @@ class GLiNER(InstructBase):
         all_losses = all_losses * mask_label.float() * weight_c
         return all_losses.sum()
 
-    def compute_score_eval(self, x):
+    def compute_score_eval(self, x, device):
         # check if classes_to_id is dict
         assert isinstance(x['classes_to_id'], dict), "classes_to_id must be a dict"
 
-        span_idx = x['span_idx'] * x['span_mask'].unsqueeze(-1)
+        span_idx = (x['span_idx'] * x['span_mask'].unsqueeze(-1)).to(device)
 
         all_types = list(x['classes_to_id'].keys())
         # multiple entity types in all_types. Prompt is appended at the start of tokens
@@ -210,7 +210,7 @@ class GLiNER(InstructBase):
 
     @torch.no_grad()
     def predict(self, x, flat_ner=False, threshold=0.5):
-        local_scores = self.compute_score_eval(x)
+        local_scores = self.compute_score_eval(x, device=next(self.parameters()).device)
         spans = []
         for i, _ in enumerate(x["tokens"]):
             local_i = local_scores[i]

--- a/notebook.ipynb
+++ b/notebook.ipynb
@@ -22,7 +22,7 @@
    },
    "outputs": [],
    "source": [
-    "flair.device = torch.device('cpu') # cpu"
+    "flair.device = torch.device('cuda:0') if torch.cuda.is_available() else torch.device('cpu')"
    ]
   },
   {
@@ -34,7 +34,7 @@
    },
    "outputs": [],
    "source": [
-    "model = load_model(\"model_30000\")\n",
+    "model = load_model(\"model_30000\").to(flair.device)\n",
     "model = model.eval()"
    ]
   },

--- a/notebook.ipynb
+++ b/notebook.ipynb
@@ -34,7 +34,7 @@
    },
    "outputs": [],
    "source": [
-    "model = load_model(\"model_30000\").to(flair.device)\n",
+    "model = load_model(\"model_30000\", device=flair.device)\n",
     "model = model.eval()"
    ]
   },

--- a/save_load.py
+++ b/save_load.py
@@ -8,7 +8,7 @@ def save_model(current_model, path):
     torch.save(dict_save, path)
 
 
-def load_model(path, model_name=None):
+def load_model(path, model_name=None, device=None):
     dict_load = torch.load(path, map_location=torch.device('cpu'))
     config = dict_load["config"]
 
@@ -17,4 +17,4 @@ def load_model(path, model_name=None):
 
     loaded_model = GLiNER(config)
     loaded_model.load_state_dict(dict_load["model_weights"])
-    return loaded_model
+    return loaded_model.to(device) if device is not None else loaded_model


### PR DESCRIPTION
The code as is would not run on my system with a single available GPU due to errors of some tensors being on cuda:0 while others being on a cpu.. 

The only way to run the code in the repo w/o modifications was to execute it with CUDA_VISIBLE_DEVICES='' 

The fixes in the code presume a specific torch device to be passed into the load_model method. Perhaps a note is needed in the readme. 