### PR TITLE
Integrate with Hugging Face, add `predict_entities` helper method

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,28 +10,9 @@ GLiNER is a Named Entity Recognition (NER) model capable of identifying any enti
 
 ## Usage
 ```python
-import torch, re
-from save_load import load_model
+from model import GLiNER
 
-model = load_model("gliner_base.pt", model_name="microsoft/deberta-v3-base")
-model = model.eval()
-
-def extract_entities(model, text, labels, threshold=0.5):
-    def tokenize_text(text):
-        return re.findall(r'\w+(?:[-_]\w+)*|\S', text.replace("\n", ""))
-
-    tokens = tokenize_text(text)
-    input_x = {"tokenized_text": tokens, "ner": None}
-    x = model.collate_fn([input_x], labels)
-    output = model.predict(x, flat_ner=True, threshold=threshold)
-
-    result_dict = {}
-
-    for start, end, ent_type in output[0]:
-        span_text = " ".join(tokens[start:end+1]).replace(" ' ", "'")
-        result_dict[span_text] = ent_type
-
-    return result_dict
+model = GLiNER.from_pretrained("urchade/gliner_base")
 
 text = """
 Cristiano Ronaldo dos Santos Aveiro (Portuguese pronunciation: [kɾiʃˈtjɐnu ʁɔˈnaldu]; born 5 February 1985) is a Portuguese professional footballer who plays as a forward for and captains both Saudi Pro League club Al Nassr and the Portugal national team. Widely regarded as one of the greatest players of all time, Ronaldo has won five Ballon d'Or awards,[note 3] a record three UEFA Men's Player of the Year Awards, and four European Golden Shoes, the most by a European player. He has won 33 trophies in his career, including seven league titles, five UEFA Champions Leagues, the UEFA European Championship and the UEFA Nations League. Ronaldo holds the records for most appearances (183), goals (140) and assists (42) in the Champions League, goals in the European Championship (14), international goals (128) and international appearances (205). He is one of the few players to have made over 1,200 professional career appearances, the most by an outfield player, and has scored over 850 official senior career goals for club and country, making him the top goalscorer of all time.
@@ -39,32 +20,32 @@ Cristiano Ronaldo dos Santos Aveiro (Portuguese pronunciation: [kɾiʃˈtjɐnu �
 
 labels = ["person", "award", "date", "competitions", "teams"]
 
-result = extract_entities(model, text, labels, threshold=0.5)
+entities = model.predict_entities(text, labels)
 
-for k, v in result.items():
-    print(f"{k}, {v}")
+for entity in entities:
+    print(entity["text"], "=>", entity["label"])
 ```
 
 ```
-- Cristiano Ronaldo dos Santos Aveiro, person
-- 5 February 1985, date
-- Al Nassr, teams
-- Portugal national team, teams
-- Ballon d'Or, award
-- UEFA Men's Player of the Year Awards, award
-- European Golden Shoes, award
-- UEFA Champions Leagues, competitions
-- UEFA European Championship, competitions
-- UEFA Nations League, competitions
-- Champions League, competitions
-- European Championship, competitions
+- Cristiano Ronaldo dos Santos Aveiro => person
+- 5 February 1985 => date
+- Al Nassr => teams
+- Portugal national team => teams
+- Ballon d'Or => award
+- UEFA Men's Player of the Year Awards => award
+- European Golden Shoes => award
+- UEFA Champions Leagues => competitions
+- UEFA European Championship => competitions
+- UEFA Nations League => competitions
+- Champions League => competitions
+- European Championship => competitions
 ```
 
 ## Named Entity Recognition benchmark result
 ![GLiNER Logo](image.png)
 
 
-## Ressources
+## Resources
 - [Pretrained Weights are available on Huggingface](https://huggingface.co/urchade)
 - [Training Data](https://drive.google.com/file/d/1MKDx73hzm9sFByJMBJhHqEuBeJzW5TsL/view?usp=sharing)
 - [Evaluation Data](https://drive.google.com/file/d/1T-5IbocGka35I7X3CE6yKe5N_Xg2lVKT/view)

--- a/model.py
+++ b/model.py
@@ -1,3 +1,8 @@
+import argparse
+import json
+from pathlib import Path
+import re
+from typing import Dict, Optional, Union
 import torch
 import torch.nn.functional as F
 from modules.layers import LstmSeq2SeqEncoder
@@ -7,9 +12,12 @@ from modules.span_rep import SpanRepLayer
 from modules.token_rep import TokenRepLayer
 from torch import nn
 from torch.nn.utils.rnn import pad_sequence
+from huggingface_hub import PyTorchModelHubMixin, hf_hub_download
+from huggingface_hub.utils import HfHubHTTPError
 
 
-class GLiNER(InstructBase):
+
+class GLiNER(InstructBase, PyTorchModelHubMixin):
     def __init__(self, config):
         super().__init__(config)
 
@@ -210,6 +218,7 @@ class GLiNER(InstructBase):
 
     @torch.no_grad()
     def predict(self, x, flat_ner=False, threshold=0.5):
+        self.eval()
         local_scores = self.compute_score_eval(x, device=next(self.parameters()).device)
         spans = []
         for i, _ in enumerate(x["tokens"]):
@@ -222,6 +231,31 @@ class GLiNER(InstructBase):
             span_i = greedy_search(span_i, flat_ner)
             spans.append(span_i)
         return spans
+
+    def predict_entities(self, text, labels, flat_ner=True, threshold=0.5):
+        tokens = []
+        start_token_idx_to_text_idx = []
+        end_token_idx_to_text_idx = []
+        for match in re.finditer(r'\w+(?:[-_]\w+)*|\S', text):
+            tokens.append(match.group())
+            start_token_idx_to_text_idx.append(match.start())
+            end_token_idx_to_text_idx.append(match.end())
+
+        input_x = {"tokenized_text": tokens, "ner": None}
+        x = self.collate_fn([input_x], labels)
+        output = self.predict(x, flat_ner=flat_ner, threshold=threshold)
+
+        entities = []
+        for start_token_idx, end_token_idx, ent_type in output[0]:
+            start_text_idx = start_token_idx_to_text_idx[start_token_idx]
+            end_text_idx = end_token_idx_to_text_idx[end_token_idx]
+            entities.append({
+                "start": start_token_idx_to_text_idx[start_token_idx],
+                "end": end_token_idx_to_text_idx[end_token_idx],
+                "text": text[start_text_idx:end_text_idx],
+                "label": ent_type,
+            })
+        return entities
 
     def evaluate(self, test_data, flat_ner=False, threshold=0.5, batch_size=12, entity_types=None):
         self.eval()
@@ -239,3 +273,140 @@ class GLiNER(InstructBase):
         evaluator = Evaluator(all_trues, all_preds)
         out, f1 = evaluator.evaluate()
         return out, f1
+
+    @classmethod
+    def _from_pretrained(
+        cls,
+        *,
+        model_id: str,
+        revision: Optional[str],
+        cache_dir: Optional[Union[str, Path]],
+        force_download: bool,
+        proxies: Optional[Dict],
+        resume_download: bool,
+        local_files_only: bool,
+        token: Union[str, bool, None],
+        map_location: str = "cpu",
+        strict: bool = False,
+        **model_kwargs,
+    ):
+        # 1. Backwards compatibility: Use "gliner_base.pt" and "gliner_multi.pt" with all data
+        filenames = ["gliner_base.pt", "gliner_multi.pt"]
+        for filename in filenames:
+            model_file = Path(model_id) / filename
+            if not model_file.exists():
+                try:
+                    model_file = hf_hub_download(
+                        repo_id=model_id,
+                        filename=filename,
+                        revision=revision,
+                        cache_dir=cache_dir,
+                        force_download=force_download,
+                        proxies=proxies,
+                        resume_download=resume_download,
+                        token=token,
+                        local_files_only=local_files_only,
+                    )
+                except HfHubHTTPError:
+                    continue
+            dict_load = torch.load(model_file, map_location=torch.device(map_location))
+            config = dict_load["config"]
+            state_dict = dict_load["model_weights"]
+            config.model_name = "microsoft/deberta-v3-base" if filename == "gliner_base.pt" else "microsoft/mdeberta-v3-base"
+            model = cls(config)
+            model.load_state_dict(state_dict, strict=strict, assign=True)
+            # Required to update flair's internals as well:
+            model.to(map_location)
+            return model
+
+        # 2. Newer format: Use "pytorch_model.bin" and "gliner_config.json"
+        from train import load_config_as_namespace
+
+        model_file = Path(model_id) / "pytorch_model.bin"
+        if not model_file.exists():
+            model_file = hf_hub_download(
+                repo_id=model_id,
+                filename="pytorch_model.bin",
+                revision=revision,
+                cache_dir=cache_dir,
+                force_download=force_download,
+                proxies=proxies,
+                resume_download=resume_download,
+                token=token,
+                local_files_only=local_files_only,
+            )
+        config_file = Path(model_id) / "gliner_config.json"
+        if not config_file.exists():
+            config_file = hf_hub_download(
+                repo_id=model_id,
+                filename="gliner_config.json",
+                revision=revision,
+                cache_dir=cache_dir,
+                force_download=force_download,
+                proxies=proxies,
+                resume_download=resume_download,
+                token=token,
+                local_files_only=local_files_only,
+            )
+        config = load_config_as_namespace(config_file)
+        model = cls(config)
+        state_dict = torch.load(model_file, map_location=torch.device(map_location))
+        model.load_state_dict(state_dict, strict=strict, assign=True)
+        model.to(map_location)
+        return model
+
+    def save_pretrained(
+        self,
+        save_directory: Union[str, Path],
+        *,
+        config: Optional[Union[dict, "DataclassInstance"]] = None,
+        repo_id: Optional[str] = None,
+        push_to_hub: bool = False,
+        **push_to_hub_kwargs,
+    ) -> Optional[str]:
+        """
+        Save weights in local directory.
+
+        Args:
+            save_directory (`str` or `Path`):
+                Path to directory in which the model weights and configuration will be saved.
+            config (`dict` or `DataclassInstance`, *optional*):
+                Model configuration specified as a key/value dictionary or a dataclass instance.
+            push_to_hub (`bool`, *optional*, defaults to `False`):
+                Whether or not to push your model to the Huggingface Hub after saving it.
+            repo_id (`str`, *optional*):
+                ID of your repository on the Hub. Used only if `push_to_hub=True`. Will default to the folder name if
+                not provided.
+            kwargs:
+                Additional key word arguments passed along to the [`~ModelHubMixin.push_to_hub`] method.
+        """
+        save_directory = Path(save_directory)
+        save_directory.mkdir(parents=True, exist_ok=True)
+
+        # save model weights/files
+        torch.save(self.state_dict(), save_directory / "pytorch_model.bin")
+
+        # save config (if provided)
+        if config is None:
+            config = self.config
+        if config is not None:
+            if isinstance(config, argparse.Namespace):
+                config = vars(config)
+            (save_directory / "gliner_config.json").write_text(json.dumps(config, indent=2))
+
+        # push to the Hub if required
+        if push_to_hub:
+            kwargs = push_to_hub_kwargs.copy()  # soft-copy to avoid mutating input
+            if config is not None:  # kwarg for `push_to_hub`
+                kwargs["config"] = config
+            if repo_id is None:
+                repo_id = save_directory.name  # Defaults to `save_directory` name
+            return self.push_to_hub(repo_id=repo_id, **kwargs)
+        return None
+
+    def to(self, device):
+        super().to(device)
+        import flair
+
+        flair.device = device
+        return self

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 torch
 transformers
+huggingface_hub
 flair
 seqeval
 tqdm


### PR DESCRIPTION
Hello!

## Preface
I'm Tom, a Machine Learning Engineer at Hugging Face, though before I started working there, I was very much into Named Entity Recognition. I developed a [library](https://github.com/tomaarsen/SpanMarkerNER) for NER, which has since seen a nice amount of usage. I'm quite fascinated by the performance that you reach with GLiNER - it was my belief previously that zero-shot NER would not be viable with BERT-like models, and it seems that you've proven me wrong. Great work here!

Now, beyond being a big fan of NER, I'm also a big fan of ease of use & reproducibility. I'm excited to see that you've uploaded two pretrained models & a great demo, and I wanted to help out with making the models even easier to use. So, I've created this pull request which integrates with Hugging Face by roughly following [this integration guide](https://huggingface.co/docs/huggingface_hub/en/guides/integrations).

## Pull Request overview
* Make `GLiNER` a subclass of `PyTorchModelHubMixin`, which adds `from_pretrained` & `push_to_hub` functionality.
* Implement a custom `save_pretrained` method
  * This method saves the model as `pytorch_model.bin` and the config as `gliner_config.json`.
* Implement a custom `_from_pretrained` method
* Add `predict_entities` helper method
* Add model cards for GLiNER-base and GLiNER-multi (outside of this PR, on Hugging Face)

## Details
## Implement a custom `_from_pretrained` method
This method is used internally in `from_pretrained` (which is what users are recommended to use). In particular, it:
1. Supports models saved as "gliner_base.pt" & "gliner_multi.pt" (i.e. what you currently have). I think this format can be a little bit confusing, as it's hard to see what the configuration options are (e.g. the `max_len` or the base `model_name`), but I've supported it for compatibility. You can use it like:
```python
from model import GLiNER

model = GLiNER.from_pretrained("urchade/gliner_base")
# or
model = GLiNER.from_pretrained("urchade/gliner_multi")

# or with local files:

model = GLiNER.from_pretrained("local_gliner_base")
# or
model = GLiNER.from_pretrained("local_gliner_multi")
# where `local_gliner_base` and `local_gliner_multi` are local directories with `gliner_base.pt` and `gliner_multi.pt` in them, respectively
```

2. Additionally, it supports a new format that I've introduced in this PR: with `pytorch_model.bin` and `gliner_config.json`. This is just like what you've done, but it saves the `state_dict` in `pytorch_model.bin` and the config in `gliner_config.json`, as opposed to everything in one file. Loading a model with this format is just as simple:
```python
from model import GLiNER

model = GLiNER.from_pretrained("tomaarsen/gliner_base")
# or
model = GLiNER.from_pretrained("tomaarsen/gliner_multi")

# or with local files:

model = GLiNER.from_pretrained("local_gliner_base")
# or
model = GLiNER.from_pretrained("local_gliner_multi")
# where `local_gliner_base` and `local_gliner_multi` are local directories with `pytorch_model.bin` and `gliner_config.json` in them
```

## A new `save_pretrained` method
This new method allows you to save a model in the format that I've described above. Obviously, I don't mean to impose a new format on you, so feel free to modify this to just use the original saving function like before, if you prefer. You can use it like so:

```python
from model import GLiNER

model = GLiNER.from_pretrained("urchade/gliner_base")
model.save_pretrained("local_gliner_base")
# and it'll save it to a directory called 'local_gliner_base'

# or
model.push_to_hub("tomaarsen/my_gliner_model")
# and it'll push the model to the Hugging Face Hub instead, under that repository name
```

## Add `predict_entities` helper method
I've introduced a helper function based on your demo code. It returns a list of entities, where each entity is a dictionary with:
* `start`: The start index that can be used to slice the input text.
* `end`: The end index that can be used to slice the input text.
* `text`: The actual entity that's being recognized.
* `label`: The corresponding label.

So, we can now simplify your README snippet to:
```python
from model import GLiNER

model = GLiNER.from_pretrained("urchade/gliner_base")

text = """
Cristiano Ronaldo dos Santos Aveiro (Portuguese pronunciation: [kɾiʃˈtjɐnu ʁɔˈnaldu]; born 5 February 1985) is a Portuguese professional footballer who plays as a forward for and captains both Saudi Pro League club Al Nassr and the Portugal national team. Widely regarded as one of the greatest players of all time, Ronaldo has won five Ballon d'Or awards,[note 3] a record three UEFA Men's Player of the Year Awards, and four European Golden Shoes, the most by a European player. He has won 33 trophies in his career, including seven league titles, five UEFA Champions Leagues, the UEFA European Championship and the UEFA Nations League. Ronaldo holds the records for most appearances (183), goals (140) and assists (42) in the Champions League, goals in the European Championship (14), international goals (128) and international appearances (205). He is one of the few players to have made over 1,200 professional career appearances, the most by an outfield player, and has scored over 850 official senior career goals for club and country, making him the top goalscorer of all time.
"""

labels = ["person", "award", "date", "competitions", "teams"]

entities = model.predict_entities(text, labels)

for entity in entities:
    print(entity["text"], "=>", entity["label"])
```

```
- Cristiano Ronaldo dos Santos Aveiro => person
- 5 February 1985 => date
- Al Nassr => teams
- Portugal national team => teams
- Ballon d'Or => award
- UEFA Men's Player of the Year Awards => award
- European Golden Shoes => award
- UEFA Champions Leagues => competitions
- UEFA European Championship => competitions
- UEFA Nations League => competitions
- Champions League => competitions
- European Championship => competitions
```

Pretty awesome! 

## New model cards
Whether your model will be used or not usually depends a lot on whether the model cards are good, so I've created two model cards for you:
* https://huggingface.co/tomaarsen/gliner_base ([raw](https://huggingface.co/tomaarsen/gliner_base/raw/main/README.md) link)
* https://huggingface.co/tomaarsen/gliner_multi ([raw](https://huggingface.co/tomaarsen/gliner_multi/raw/main/README.md) link)

Please feel free to copy these READMEs over to your models, and then I will take mine offline again, as I don't want any credit for your models :) The "Usage" snippets already refer to your models. Also, if you want, then you can copy the full repositories, i.e. with the updated model format, but that's up to you.

## Note
There are some design decisions that you can make based on your preferences. For example, the name of `predict_entities`, the dictionary keys that it outputs (`start`, `end`, `text`, `label`), the saved model format, etc. You can make these decisions as you see fit, I don't want to impose my choices onto your work here.

## Note 2
If you're interested, it might be worthwhile to turn this project into a Python package. You might have to move some of the code into a `gliner` or `src` directory and create a `setup.py` or `pyproject.toml`, but then users can do:
```
pip install gliner
```
&
```
from gliner import GLiNER
```

I think that might be valuable.

- Tom Aarsen