### PR TITLE
[`fix`] Resolve PyPI install issues

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -73,7 +73,7 @@ rm -rf build && rm -rf dist
 Then run:
 
 ```bash
-python setup.py bdist_wheel && python setup.py sdist
+python -m build
 ```
 
 This will create two folders, `build` and a `dist` with the new versions of your package. These contain a 1) source distribution and a 2) wheel.

--- a/gliner/model.py
+++ b/gliner/model.py
@@ -5,6 +5,7 @@ import re
 from typing import Dict, Optional, Union
 import torch
 import torch.nn.functional as F
+import yaml
 from gliner.modules.layers import LstmSeq2SeqEncoder
 from gliner.modules.base import InstructBase
 from gliner.modules.evaluator import Evaluator, greedy_search
@@ -350,8 +351,6 @@ class GLiNER(InstructBase, PyTorchModelHubMixin):
             return model
 
         # 2. Newer format: Use "pytorch_model.bin" and "gliner_config.json"
-        from train import load_config_as_namespace
-
         model_file = Path(model_id) / "pytorch_model.bin"
         if not model_file.exists():
             model_file = hf_hub_download(
@@ -440,3 +439,9 @@ class GLiNER(InstructBase, PyTorchModelHubMixin):
 
         flair.device = device
         return self
+
+
+def load_config_as_namespace(config_file):
+    with open(config_file, 'r') as f:
+        config_dict = yaml.safe_load(f)
+    return argparse.Namespace(**config_dict)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,8 @@
 requires = ["setuptools>=61.0.0"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools]
-packages = ["gliner"]
+[tool.setuptools.packages.find]
+include = ["gliner", "gliner.*"]
 
 [tool.setuptools.dynamic]
 version = {attr = "gliner.__version__"}

--- a/train.py
+++ b/train.py
@@ -2,13 +2,13 @@ import argparse
 import os
 
 import torch
-import yaml
 from tqdm import tqdm
 from transformers import get_cosine_schedule_with_warmup
 
 # from model_nested import NerFilteredSemiCRF
 from gliner import GLiNER
 from gliner.modules.run_evaluation import sample_train_data
+from gliner.model import load_config_as_namespace
 import json
 
 
@@ -78,12 +78,6 @@ def create_parser():
     parser.add_argument("--config", type=str, default="config.yaml", help="Path to config file")
     parser.add_argument('--log_dir', type=str, default='logs', help='Path to the log directory')
     return parser
-
-
-def load_config_as_namespace(config_file):
-    with open(config_file, 'r') as f:
-        config_dict = yaml.safe_load(f)
-    return argparse.Namespace(**config_dict)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hello!

## Pull Request overview
* Resolve PyPI install issues
  * Use `["gliner", "gliner.*"]` to include both `model.py` as well as the subdirectories (`modules` in this case)
  * Fix broken `from train import ...` import in `GLiNER.from_pretrained`
  * Update the wheel/source builder code to `python -m build`. That should also create a `dist` directory with 2 files.

## Details
I believe that this should work now. I tested it locally, and it seems to work there. You can try to upload to test.pypi to test if you want. You can also update the version according to the [Release guide](https://github.com/urchade/GLiNER/blob/main/RELEASE.md).

- Tom Aarsen