### PR TITLE
Fix GPU Training Error

### DIFF
--- a/train.py
+++ b/train.py
@@ -103,7 +103,7 @@ if __name__ == "__main__":
         model = GLiNER(config)
 
     if torch.cuda.is_available():
-        model = model.cuda()
+        model = model.to('cuda')
 
     lr_encoder = float(config.lr_encoder)
     lr_others = float(config.lr_others)


### PR DESCRIPTION
Current implementation in model.py utilizes `model.cuda()` for setting up the GPU device. However, this approach does not take into account Flair's device handling, leading to errors during GPU training.

In this PR, I've modified to use the `model.to` function implemented in model.py instead of `model.cuda()` to fix the behavior described above. I didn't make any other modifications because the to function is already implemented to set flair's device.