### PR TITLE
Use most general Exception in from_pretrained

### DIFF
--- a/gliner/model.py
+++ b/gliner/model.py
@@ -14,7 +14,6 @@ from gliner.modules.token_rep import TokenRepLayer
 from torch import nn
 from torch.nn.utils.rnn import pad_sequence
 from huggingface_hub import PyTorchModelHubMixin, hf_hub_download
-from huggingface_hub.utils import HfHubHTTPError
 
 
 
@@ -362,7 +361,7 @@ class GLiNER(InstructBase, PyTorchModelHubMixin):
                         token=token,
                         local_files_only=local_files_only,
                     )
-                except HfHubHTTPError:
+                except Exception:
                     continue
             dict_load = torch.load(model_file, map_location=torch.device(map_location))
             config = dict_load["config"]


### PR DESCRIPTION
Addresses #35 (not sure if it solves it 100%)

Hello!

## Pull Request overview
* Use most general `Exception` in from_pretrained

## Details
Apologies for the delay on this, I was very busy last week. In #35, the issue seems to be that the `hf_hub_download` fails & causes a crash when loading a local file. However, when loading a local file, this method is expected to fail (after all, the path is not a remote repository on Hugging Face), but it's meant to be caught by this exception:
https://github.com/urchade/GLiNER/blob/e15c22a01b1a018674f725428ba1325c723df307/gliner/model.py#L348-L366

That doesn't seem to happen, so let's make the exception more general. Then these exceptions will be caught as expected & the code can move onto the section for local loading. That's the theory, anyways, I haven't tested this well myself.

- Tom Aarsen