### PR TITLE
adding SpaCyTokenSplitter

### DIFF
--- a/gliner/model.py
+++ b/gliner/model.py
@@ -11,7 +11,7 @@ from gliner.modules.base import InstructBase
 from gliner.modules.evaluator import Evaluator, greedy_search
 from gliner.modules.span_rep import SpanRepLayer
 from gliner.modules.token_rep import TokenRepLayer
-from gliner.modules.token_splitter import WhitespaceTokenSplitter, MecabKoTokenSplitter
+from gliner.modules.token_splitter import WhitespaceTokenSplitter, MecabKoTokenSplitter, SpaCyTokenSplitter
 from torch import nn
 from torch.nn.utils.rnn import pad_sequence
 from huggingface_hub import PyTorchModelHubMixin, hf_hub_download
@@ -26,6 +26,9 @@ class GLiNER(InstructBase, PyTorchModelHubMixin):
 
         if "token_splitter" not in self.config:
             self.token_splitter = WhitespaceTokenSplitter()
+        elif self.config.token_splitter == "spacy":
+            lang = getattr(self.config, 'token_splitter_lang', None)
+            self.token_splitter = SpaCyTokenSplitter(lang=lang)
         elif self.config.token_splitter == "mecab-ko":
             self.token_splitter = MecabKoTokenSplitter()
 

--- a/gliner/modules/token_splitter.py
+++ b/gliner/modules/token_splitter.py
@@ -1,5 +1,5 @@
 import re
-
+import spacy
 
 class TokenSplitterBase():
     def __init__(self):
@@ -16,6 +16,18 @@ class WhitespaceTokenSplitter(TokenSplitterBase):
     def __call__(self, text):
         for match in self.whitespace_pattern.finditer(text):
             yield match.group(), match.start(), match.end()
+
+
+class SpaCyTokenSplitter(TokenSplitterBase):
+    def __init__(self, lang=None):
+        if lang is None:
+            lang = 'en'  # Default to English if no language is specified
+        self.nlp = spacy.blank(lang)
+
+    def __call__(self, text):
+        doc = self.nlp(text)
+        for token in doc:
+            yield token.text, token.idx, token.idx + len(token.text)            
 
 
 class MecabKoTokenSplitter(TokenSplitterBase):

--- a/gliner/modules/token_splitter.py
+++ b/gliner/modules/token_splitter.py
@@ -1,5 +1,5 @@
 import re
-import spacy
+
 
 class TokenSplitterBase():
     def __init__(self):
@@ -20,6 +20,12 @@ class WhitespaceTokenSplitter(TokenSplitterBase):
 
 class SpaCyTokenSplitter(TokenSplitterBase):
     def __init__(self, lang=None):
+        try:
+            import spacy # noqa
+        except ModuleNotFoundError as error:
+            raise error.__class__(
+                "Please install spacy with: `pip install spacy`"
+            )
         if lang is None:
             lang = 'en'  # Default to English if no language is specified
         self.nlp = spacy.blank(lang)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ huggingface_hub>=0.21.4
 flair==0.13.1
 seqeval
 tqdm
+spacy

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ flair==0.13.1
 seqeval
 tqdm
 spacy
+scipy==1.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,4 @@ huggingface_hub>=0.21.4
 flair==0.13.1
 seqeval
 tqdm
-spacy
 scipy==1.12


### PR DESCRIPTION
@urchade @tomaarsen Please review:
The Problem: The `WhitespaceTokenSplitter` is not splitting properly if inside a numeric value there are commas, point or minus.
Example: text = “number 1.1 2,2 -3”
WhitespaceTokenSplitter output:
Token: ‘number’ at indices: (0, 6)
Token: ‘1’ at indices: (7, 8)
Token: ‘.’ at indices: (8, 9)
Token: ‘1’ at indices: (9, 10)
Token: ‘2’ at indices: (11, 12)
Token: ‘,’ at indices: (12, 13)
Token: ‘2’ at indices: (13, 14)
Token: ‘-’ at indices: (15, 16)
Token: ‘3’ at indices: (16, 17)
SpaCyTokenSplitter (English) output:
Token: ‘number’ at indices: (0, 6)
Token: ‘1.1’ at indices: (7, 10)
Token: ‘2,2’ at indices: (11, 14)
Token: ‘-3’ at indices: (15, 17)
solution: Support of spacy.blank by adding this class `SpaCyTokenSplitter` in the `token_splitter.py`.

Example of how to use it?
Add to the `gliner_config.json` the following keys and value: “token_splitter”: “spacy”, “token_splitter_lang”: “en”. (or any other language that spacy supports)