### PR TITLE
fix: pin scipy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ huggingface_hub>=0.21.4
 flair==0.13.1
 seqeval
 tqdm
+scipy==1.12


### PR DESCRIPTION
latest scipy yields

ImportError: cannot import name 'triu' from 'scipy.linalg'