### PR TITLE
docs: add EmergentMethods/gliner_medium_news-v2.1 to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ GLiNER is a Named Entity Recognition (NER) model capable of identifying any enti
 
 
 - **GLiNER NuNerZero span**: `numind/NuNER_Zero-span`  *(MIT)* - +4.5% more powerful GLiNER Large v2.1
+- **GLiNER News**: `EmergentMethods/gliner_medium_news-v2.1` *(Apache 2.0)* 9.5% improvement over GLiNER Large v2.1 on 18 benchmark datasets
 
 ##### 🇬🇧 English word-level Entity Recognition
 


### PR DESCRIPTION
@th0rntwig and I recently built a [grounded synthetic dataset for news](https://huggingface.co/datasets/EmergentMethods/AskNews-NER-v0), geared toward improving the representation of underrepresented entities/topics. We used this dataset to fine-tune [gliner_medium_news-v2.1](https://huggingface.co/EmergentMethods/gliner_medium_news-v2.1), and we were pleasantly surprised to find out that it improved the performance by up to 9.5% (gliner_medium_news-v2.1 vs gliner_large-v2.1).

We are using this fine-tune for super high-throughput entity extraction on news articles now, and it barely makes a dent to our server compute capacity. This is only possible due to the lightweight nature of GLiNER, and the power of the base model weights/architecture.

Thanks to @urchade for some tips along the way on the training.

