### PR TITLE
Add total limits on the number of checkpoints to save

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -36,6 +36,8 @@ val_data_dir: "none"
 # Use "none" if no pretrained model is being used
 prev_path: "none"
 
+save_total_limit: 10 #maximum amount of checkpoints to save
+
 # Advanced Training Settings
 size_sup: -1
 max_types: 25

--- a/config_span.yaml
+++ b/config_span.yaml
@@ -36,6 +36,8 @@ val_data_dir: "none"
 # Use "none" if no pretrained model is being used
 prev_path: "none"
 
+save_total_limit: 10 #maximum amount of checkpoints to save
+
 # Advanced Training Settings
 size_sup: -1
 max_types: 25

--- a/config_token.yaml
+++ b/config_token.yaml
@@ -36,6 +36,8 @@ val_data_dir: "NER_datasets"
 # Use "none" if no pretrained model is being used
 prev_path: "none"
 
+save_total_limit: 10 #maximum amount of checkpoints to save
+
 # Advanced Training Settings
 size_sup: -1
 max_types: 25

--- a/train.py
+++ b/train.py
@@ -22,7 +22,7 @@ def save_top_k_checkpoints(model: GLiNER, save_path: str, checkpoint: int, top_k
     Save the top-k checkpoints (latest k checkpoints) of a model and tokenizer.
 
     Parameters:
-        model (PreTrainedModel): The model to save.
+        model (GLiNER): The model to save.
         save_path (str): The directory path to save the checkpoints.
         top_k (int): The number of top checkpoints to keep. Defaults to 5.
     """


### PR DESCRIPTION
Introduced a new parameter, `save_total_limit`, that sets limits on how many checkpoints can be saved in the log directory.