### PR TITLE
Fix dup labels list

### DIFF
--- a/gliner/model.py
+++ b/gliner/model.py
@@ -128,7 +128,9 @@ class GLiNER(nn.Module, PyTorchModelHubMixin):
         all_tokens = []
         all_start_token_idx_to_text_idx = []
         all_end_token_idx_to_text_idx = []
-
+        # preserving the order of labels
+        labels = list(dict.fromkeys(labels))
+        
         for text in texts:
             tokens = []
             start_token_idx_to_text_idx = []

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,6 @@
 from gliner import GLiNER
 
+
 def test_span_model():
     model = GLiNER.from_pretrained("gliner-community/gliner_small-v2.5")
 
@@ -7,8 +8,8 @@ def test_span_model():
     Cristiano Ronaldo dos Santos Aveiro (Portuguese pronunciation: [kɾiʃˈtjɐnu ʁɔˈnaldu]; born 5 February 1985) is a Portuguese professional footballer who plays as a forward for and captains both Saudi Pro League club Al Nassr and the Portugal national team. Widely regarded as one of the greatest players of all time, Ronaldo has won five Ballon d'Or awards,[note 3] a record three UEFA Men's Player of the Year Awards, and four European Golden Shoes, the most by a European player. He has won 33 trophies in his career, including seven league titles, five UEFA Champions Leagues, the UEFA European Championship and the UEFA Nations League. Ronaldo holds the records for most appearances (183), goals (140) and assists (42) in the Champions League, goals in the European Championship (14), international goals (128) and international appearances (205). He is one of the few players to have made over 1,200 professional career appearances, the most by an outfield player, and has scored over 850 official senior career goals for club and country, making him the top goalscorer of all time.
     """
 
-    labels = ["person", "award", "date", "competitions", "teams"]
+    labels = ["person", "award", "date", "competitions", "teams", "person"]
 
     entities = model.predict_entities(text, labels)
 
-    assert len(entities)>0
+    assert len(entities) > 0


### PR DESCRIPTION
The code will break when the user has duplicated labels list as input, as shown in the following example:
```
    text = """
    Cristiano Ronaldo dos Santos Aveiro (Portuguese pronunciation: [kɾiʃˈtjɐnu ʁɔˈnaldu]; born 5 February 1985) is a Portuguese professional footballer who plays as a forward for and captains both Saudi Pro League club Al Nassr and the Portugal national team. Widely regarded as one of the greatest players of all time, Ronaldo has won five Ballon d'Or awards,[note 3] a record three UEFA Men's Player of the Year Awards, and four European Golden Shoes, the most by a European player. He has won 33 trophies in his career, including seven league titles, five UEFA Champions Leagues, the UEFA European Championship and the UEFA Nations League. Ronaldo holds the records for most appearances (183), goals (140) and assists (42) in the Champions League, goals in the European Championship (14), international goals (128) and international appearances (205). He is one of the few players to have made over 1,200 professional career appearances, the most by an outfield player, and has scored over 850 official senior career goals for club and country, making him the top goalscorer of all time.
    """

    labels = ["person", "award", "date", "competitions", "teams", "person"]

    entities = model.predict_entities(text, labels)
```

it will raise the following error:
```
File: ..../gliner/decoding/decoder.py:93, in TokenDecoder.decode(self, tokens, id_to_classes, model_output, flat_ner, threshold, multi_label)
     88                 continue
     89             print(
     90                 (st, ed, cls_st + 1, ins.mean().item())
     91             )
     92             span_i.append(
---> 93                 (st, ed, id_to_classes[cls_st + 1], ins.mean().item())
     94             )
     95 span_i = self.greedy_search(span_i, flat_ner, multi_label=multi_label)
     96 spans.append(span_i)

KeyError: 1
```