### PR TITLE
Bug fix: Tensors should not be moved to a device when using onnx

### DIFF
--- a/gliner/model.py
+++ b/gliner/model.py
@@ -340,9 +340,10 @@ class GLiNER(nn.Module, PyTorchModelHubMixin):
         # Iterate over data batches
         for batch in data_loader:
             # Move the batch to the appropriate device
-            for key in batch:
-                if isinstance(batch[key], torch.Tensor):
-                    batch[key] = batch[key].to(self.device)
+            if not self.onnx_model:
+                for key in batch:
+                    if isinstance(batch[key], torch.Tensor):
+                        batch[key] = batch[key].to(self.device)
 
             # Perform predictions
             model_output = self.model(**batch)[0]


### PR DESCRIPTION
Without this, using `run(...)` results in an exception because `device` does not exist.