### PR TITLE
Bug fix: Tensors should not be moved to a device when using onnx (in evaluate function)

### DIFF
--- a/gliner/model.py
+++ b/gliner/model.py
@@ -508,16 +508,16 @@ class GLiNER(nn.Module, PyTorchModelHubMixin):
             dataset, batch_size=batch_size, shuffle=False, collate_fn=collator
         )
 
-        device = self.device
         all_preds = []
         all_trues = []
 
         # Iterate over data batches
         for batch in data_loader:
             # Move the batch to the appropriate device
-            for key in batch:
-                if isinstance(batch[key], torch.Tensor):
-                    batch[key] = batch[key].to(device)
+            if not self.onnx_model:
+                for key in batch:
+                    if isinstance(batch[key], torch.Tensor):
+                        batch[key] = batch[key].to(self.device)
 
             # Perform predictions
             model_output = self.model(**batch)[0]


### PR DESCRIPTION
At the moment it is not possible to evaluate an ONNX model (using `evaluate(...)` function) because `device` attribute does not exist. Hence this little fix...