### PR TITLE
Add GPU Support for ONNX Models

### DIFF
--- a/gliner/model.py
+++ b/gliner/model.py
@@ -835,7 +835,7 @@ class GLiNER(nn.Module, PyTorchModelHubMixin):
                     ort.GraphOptimizationLevel.ORT_ENABLE_ALL
                 )
             providers = ['CPUExecutionProvider']
-            if map_location == 'cuda':
+            if "cuda" in map_location:
                 if not torch.cuda.is_available():
                     raise RuntimeError("CUDA is not available but `map_location` is set to 'cuda'.")
                 providers = ['CUDAExecutionProvider']

--- a/gliner/model.py
+++ b/gliner/model.py
@@ -106,6 +106,11 @@ class GLiNER(nn.Module, PyTorchModelHubMixin):
 
     @property
     def device(self):
+        if self.onnx_model:
+            providers = self.model.session.get_providers()
+            if 'CUDAExecutionProvider' in providers:
+                return torch.device('cuda')
+            return torch.device('cpu')
         device = next(self.model.parameters()).device
         return device
 
@@ -209,13 +214,12 @@ class GLiNER(nn.Module, PyTorchModelHubMixin):
             }
         )
 
-        if not self.onnx_model:
-            device = self.device
-            for key in model_input:
-                if model_input[key] is not None and isinstance(
-                    model_input[key], torch.Tensor
-                ):
-                    model_input[key] = model_input[key].to(device)
+        device = self.device
+        for key in model_input:
+            if model_input[key] is not None and isinstance(
+                model_input[key], torch.Tensor
+            ):
+                model_input[key] = model_input[key].to(device)
 
         return model_input, raw_batch
 
@@ -514,10 +518,9 @@ class GLiNER(nn.Module, PyTorchModelHubMixin):
         # Iterate over data batches
         for batch in data_loader:
             # Move the batch to the appropriate device
-            if not self.onnx_model:
-                for key in batch:
-                    if isinstance(batch[key], torch.Tensor):
-                        batch[key] = batch[key].to(self.device)
+            for key in batch:
+                if isinstance(batch[key], torch.Tensor):
+                    batch[key] = batch[key].to(self.device)
 
             # Perform predictions
             model_output = self.model(**batch)[0]
@@ -831,7 +834,12 @@ class GLiNER(nn.Module, PyTorchModelHubMixin):
                 session_options.graph_optimization_level = (
                     ort.GraphOptimizationLevel.ORT_ENABLE_ALL
                 )
-            ort_session = ort.InferenceSession(model_file, session_options)
+            providers = ['CPUExecutionProvider']
+            if map_location == 'cuda':
+                if not torch.cuda.is_available():
+                    raise RuntimeError("CUDA is not available but `map_location` is set to 'cuda'.")
+                providers = ['CUDAExecutionProvider']
+            ort_session = ort.InferenceSession(model_file, session_options, providers=providers)
             if config.span_mode == "token_level":
                 model = TokenORTModel(ort_session)
             else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "transformers>=4.38.2",
     "huggingface_hub>=0.21.4",
     "tqdm",
-    "onnxruntime",
+    "onnxruntime-gpu",
     "sentencepiece",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 torch>=2.0.0
 transformers>=4.38.2
 huggingface_hub>=0.21.4
-onnxruntime
+onnxruntime-gpu
 sentencepiece
 tqdm


### PR DESCRIPTION
This PR enables GPU acceleration for ONNX models in GLiNER by adding support for CUDA execution. 
The changes ensure that ONNX models can leverage GPU resources when available, leading to improved inference performance.

**Changes**

1. Updated Device Determination
Modified the device property to correctly determine the device for both PyTorch and ONNX models.
For ONNX models, the code now checks if `CUDAExecutionProvider` is in the execution providers and returns the appropriate device.

2. Unified Tensor Device Placement
Now, tensors are always moved to `self.device`, ensuring correct tensor placement and consistency between ONNX and PyTorch models.

3. Modified Model Loading
Adjusted the `_from_pretrained` method to set ONNX Runtime execution providers based on the map_location parameter.
If map_location is 'cuda', it sets the providers to `['CUDAExecutionProvider']`; otherwise, it defaults to `['CPUExecutionProvider']`.

4. Updated Dependencies
Added `onnxruntime-gpu` to `pyproject.toml` and `requirements.txt` to ensure GPU support


**Usage**
To enable GPU acceleration for ONNX models:
```
model = GLiNERModel.from_pretrained(
    'path_or_repo_id',
    load_onnx_model=True,
    onnx_model_file='model.onnx',
    map_location='cuda'  # Set to 'cpu' if GPU is not available
)
```