### PR TITLE
Change how the config file is loaded

### DIFF
--- a/gliner/model.py
+++ b/gliner/model.py
@@ -781,7 +781,8 @@ class GLiNER(nn.Module, PyTorchModelHubMixin):
                 tokenizer = AutoTokenizer.from_pretrained(model_dir)
             else:
                 tokenizer = None
-        config_ = json.load(open(config_file))
+        with open(config_file, "r") as f:
+            config_ = json.load(f)
         config = GLiNERConfig(**config_)
 
         if _attn_implementation is not None:


### PR DESCRIPTION
The PR changes how the `config_file` is opened and read (making it consistent with other parts of file loading in GLiNER).

Also, the change should resolve the following warning emitted when loading a GLiNER model:

```
/site-packages/gliner/model.py:783: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/runner/.cache/huggingface/hub/models--urchade--gliner_multi_pii-v1/snapshots/1fcf13e85f4eef5394e1fcd406cf2ca9ea82351d/gliner_config.json' mode='r' encoding='UTF-8'>
  config_ = json.load(open(config_file))
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```