### PR TITLE
make `onnxruntime-gpu` optional

### DIFF
--- a/README_Extended.md
+++ b/README_Extended.md
@@ -75,6 +75,12 @@ To begin using the GLiNER model, you can install the GLiNER Python library throu
 !pip install gliner
 ```
 
+If you intend to use the GPU-backed ONNX runtime, install GLiNER with the GPU feature. This also installs the `onnxruntime-gpu` dependency.
+
+```bash
+!pip install gliner[gpu]
+```
+
 ### Install via Conda
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,11 +39,15 @@ dependencies = [
     "transformers>=4.38.2",
     "huggingface_hub>=0.21.4",
     "tqdm",
-    "onnxruntime-gpu",
+    "onnxruntime",
     "sentencepiece",
 ]
 
 dynamic = ["version"]
+
+[project.optional-dependencies]
+gpu = ["onnxruntime-gpu"]
+
 
 [project.urls]
 Homepage = "https://github.com/urchade/GLiNER"


### PR DESCRIPTION
closes #222 

gpu runtime can now be installed with `pip install -e .[gpu]`. The cpu install remains `pip install -e .`
