### PR TITLE
Add support of Flash DeBERTa

### DIFF
--- a/README_Extended.md
+++ b/README_Extended.md
@@ -228,6 +228,27 @@ Bill Gates => person
 Microsoft => organization
 ```
 
+## Using FlashDeBERTa
+
+Most GLiNER models use the DeBERTa encoder as their backbone. This architecture offers strong token classification performance and typically requires less data to achieve good results. However, a major drawback has been its slower inference speed, and until recently, there was no flash attention implementation compatible with DeBERTa's disentangled attention mechanism.
+
+To address this, [FlashDeBERTa](https://github.com/Knowledgator/FlashDeBERTa) was introduced.
+
+To use `FlashDeBERTa` with GLiNER, install it with:
+
+```bash
+pip install flashdeberta -U
+```
+
+GLiNER will automatically detect and use `FlashDeBERTa`. If needed, you can switch to the standard `eager` attention mechanism by specifying the attention implementation:
+
+```python
+model = GLiNER.from_pretrained("urchade/gliner_mediumv2.1", _attn_implementation="eager")
+```
+
+`FlashDeBERTa` provides up to a 3× speed boost for typical sequence lengths—and even greater improvements for longer sequences.
+
+
 ## Multitask Usage
 GLiNER-Multitask models are designed to extract relevant information from plain text based on a user-provided custom prompt. The advantage of such encoder-based multitask models is that they enable efficient and more controllable information extraction with a single model that reduces costs on computational and storage resources. Moreover, such encoder models are more interpretable, efficient and tunable than LLMs, which are hard to fine-tune and use for information extraction.
 

--- a/gliner/config.py
+++ b/gliner/config.py
@@ -30,6 +30,7 @@ class GLiNERConfig(PretrainedConfig):
                  labels_encoder_config: Optional[dict] = None,
                  ent_token = "<<ENT>>",
                  sep_token = "<<SEP>>",
+                 _attn_implementation = None,
                  **kwargs):
         super().__init__(**kwargs)
         if isinstance(encoder_config, dict):
@@ -68,6 +69,7 @@ class GLiNERConfig(PretrainedConfig):
         self.embed_ent_token = embed_ent_token
         self.ent_token = ent_token
         self.sep_token = sep_token
+        self._attn_implementation = _attn_implementation
 
 # Register the configuration
 from transformers import CONFIG_MAPPING

--- a/gliner/model.py
+++ b/gliner/model.py
@@ -789,7 +789,8 @@ class GLiNER(nn.Module, PyTorchModelHubMixin):
         config = GLiNERConfig(**config_)
 
         if _attn_implementation is not None:
-            config.encoder_config._attn_implementation = _attn_implementation
+            config._attn_implementation = _attn_implementation
+            
         if max_length is not None:
             config.max_len = max_length
         if max_width is not None:

--- a/gliner/modeling/encoder.py
+++ b/gliner/modeling/encoder.py
@@ -11,6 +11,7 @@ from ..utils import is_module_available, MissedPackageException
 IS_LLM2VEC = is_module_available('llm2vec')
 IS_PEFT = is_module_available('peft')
 IS_TURBOT5 = is_module_available('turbot5')
+IS_FLASHDEBERTA = is_module_available('flashdeberta')
 
 if IS_LLM2VEC:
     from llm2vec.models import MistralBiModel, LlamaBiModel, GemmaBiModel, Qwen2BiModel
@@ -28,6 +29,11 @@ if IS_TURBOT5:
 else:
     from transformers import T5EncoderModel
 
+if IS_FLASHDEBERTA:
+    from flashdeberta import FlashDebertaV2Model as DebertaV2Model
+else:
+    from transformers import DebertaV2Model
+
 if IS_PEFT:
     from peft import LoraConfig, get_peft_model
 
@@ -43,8 +49,12 @@ class Transformer(nn.Module):
             if config.vocab_size!=-1:
                 encoder_config.vocab_size = config.vocab_size
 
+        if config._attn_implementation is not None and not labels_encoder:
+            encoder_config._attn_implementation = config._attn_implementation
+
         config_name = encoder_config.__class__.__name__
 
+        kwargs = {}
         if config_name in DECODER_MODEL_MAPPING:
             if not IS_LLM2VEC:
                 raise MissedPackageException(f"The llm2vec package must be installed to use this decoder model: {config_name}")
@@ -52,14 +62,14 @@ class Transformer(nn.Module):
                 print('Loading decoder model using LLM2Vec...')
                 ModelClass = DECODER_MODEL_MAPPING[config_name]
             custom = True
-            kwargs = {}
         elif config_name in {'T5Config', 'MT5Config'}:
             custom = True
             ModelClass = T5EncoderModel
             if IS_TURBOT5:
                 kwargs = {"attention_type": 'flash'}
-            else:
-                kwargs = {}
+        elif config_name in {'DebertaV2Config'}:
+            custom = True
+            ModelClass = DebertaV2Model
         else:
             custom = False
             ModelClass = AutoModel

--- a/gliner/utils.py
+++ b/gliner/utils.py
@@ -1,4 +1,5 @@
 import argparse
+import warnings
 import yaml
 
 def load_config_as_namespace(config_file):


### PR DESCRIPTION
This PR introduces support for Flash DeBERTa that uses a custom Triton kernel, designed to increase inference speed for DeBERTa-based models.

In addition, some bugs were fixed related to setting different attention implementations. 

The information on how to use the flashdeberta package was added to the extended readme.