### PR TITLE
Add return index for relation extraction

### DIFF
--- a/gliner/multitask/relation_extraction.py
+++ b/gliner/multitask/relation_extraction.py
@@ -85,7 +85,7 @@ class GLiNERRelationExtractor(GLiNERBasePipeline):
             list: List of predicted labels for each input.
         """
         batch_predicted_relations = []
-        shift = len(self.prompt)
+        shift = len(self.prompt) #subtract the prompt length to get the original text indexes
         for prediction in predictions:
             # Sort predictions by score in descending order
             curr_relations = []
@@ -104,9 +104,9 @@ class GLiNERRelationExtractor(GLiNERBasePipeline):
                     start = target.get('start')
                     end   = target.get('end')
                     if start is not None:
-                        start += shift
+                        start -= shift
                     if end is not None:
-                        end += shift
+                        end -= shift
                     rel['start'] = start
                     rel['end']   = end
                 curr_relations.append(relation)

--- a/gliner/multitask/relation_extraction.py
+++ b/gliner/multitask/relation_extraction.py
@@ -29,7 +29,7 @@ class GLiNERRelationExtractor(GLiNERBasePipeline):
 
     prompt = "Extract relationships between entities from the text: "
 
-    def __init__(self, model_id: str = None, model: GLiNER = None, device: str = 'cuda:0', ner_threshold: float = 0.5, rel_threshold: float = 0.5, prompt: Optional[str] = None):
+    def __init__(self, model_id: str = None, model: GLiNER = None, device: str = 'cuda:0', ner_threshold: float = 0.5, rel_threshold: float = 0.5, return_index: bool = False, prompt: Optional[str] = None):
         """
         Initializes the GLiNERRelationExtractor.
 
@@ -43,6 +43,7 @@ class GLiNERRelationExtractor(GLiNERBasePipeline):
         """
         # Use the provided prompt or default to the class-level prompt
         prompt = prompt if prompt is not None else self.prompt
+        self.return_index = return_index
         super().__init__(model_id=model_id, model=model, prompt=prompt, device=device)
 
     def prepare_texts(self, texts: List[str], **kwargs):
@@ -99,6 +100,9 @@ class GLiNERRelationExtractor(GLiNERBasePipeline):
                     "target": target_ent.strip(),
                     "score": score
                 }
+                if self.return_index:
+                    relation['start'] = target.get('start', None)
+                    relation['end']   = target.get('end', None)
                 curr_relations.append(relation)
             batch_predicted_relations.append(curr_relations)
 

--- a/gliner/multitask/relation_extraction.py
+++ b/gliner/multitask/relation_extraction.py
@@ -85,7 +85,7 @@ class GLiNERRelationExtractor(GLiNERBasePipeline):
             list: List of predicted labels for each input.
         """
         batch_predicted_relations = []
-
+        shift = len(self.prompt)
         for prediction in predictions:
             # Sort predictions by score in descending order
             curr_relations = []
@@ -101,13 +101,19 @@ class GLiNERRelationExtractor(GLiNERBasePipeline):
                     "score": score
                 }
                 if self.return_index:
-                    relation['start'] = target.get('start', None)
-                    relation['end']   = target.get('end', None)
+                    start = target.get('start')
+                    end   = target.get('end')
+                    if start is not None:
+                        start += shift
+                    if end is not None:
+                        end += shift
+                    rel['start'] = start
+                    rel['end']   = end
                 curr_relations.append(relation)
             batch_predicted_relations.append(curr_relations)
 
         return batch_predicted_relations
-    
+
     def __call__(self, texts: Union[str, List[str]], relations: List[str]=None, 
                                 entities: List[str] = ['named entity'], 
                                 relation_labels: Optional[List[List[str]]]=None, 


### PR DESCRIPTION
add a return_index parameter to return the start, end of the extracted relations from source. Helpful in highlighting where the correct location of the extraction was if there are multiple mentions of the text in the sentence.