### PR TITLE
Add StanzaWordsSplitter for language-aware tokenization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,8 @@ tokenizers = [
     "jieba3",
     "camel_tools",
     "indic-nlp-library",
-    "spacy"
+    "spacy",
+    "stanza"
 ]
 
 

--- a/tests/test_tokenizer_stanza.py
+++ b/tests/test_tokenizer_stanza.py
@@ -1,0 +1,23 @@
+import importlib.util, pytest
+
+if (
+    importlib.util.find_spec("stanza") is None
+    or importlib.util.find_spec("langdetect") is None
+):
+    pytest.skip("stanza/langdetect not installed", allow_module_level=True)
+
+from gliner.data_processing.tokenizer import StanzaWordsSplitter
+
+
+@pytest.fixture(scope="module")
+def splitter():
+    return StanzaWordsSplitter(default_lang="en", download_on_missing=True)
+
+
+def test_english(splitter):
+    assert [t[0] for t in splitter("Hello world!")] == ["Hello", "world", "!"]
+
+
+def test_french(splitter):
+    tok = next(splitter("Bonjour tout le monde"))
+    assert tok[0] == "Bonjour"


### PR DESCRIPTION
This PR adds a new tokenizer class `StanzaWordsSplitter` that uses langdetect + stanza pipelines:
- Auto-detects language of input text
- Unit test under `tests/test_tokenizer_stanza.py`

Optional dependencies updated in pyproject.toml:
- stanza