### PR TITLE
Fixed ALL_LAYERNORM_LAYERS bug

### DIFF
--- a/gliner/training/trainer.py
+++ b/gliner/training/trainer.py
@@ -8,8 +8,9 @@ from transformers.training_args import OptimizerNames
 from transformers.trainer import (
     is_sagemaker_mp_enabled,
     get_parameter_names,
-    ALL_LAYERNORM_LAYERS,
+   
 )
+from transformers.pytorch_utils import ALL_LAYERNORM_LAYERS
 from transformers.trainer_utils import seed_worker
 
 if transformers.utils.is_apex_available():

--- a/gliner/training/trainer.py
+++ b/gliner/training/trainer.py
@@ -10,7 +10,7 @@ from transformers.trainer import (
     get_parameter_names,
    
 )
-from transformers.pytorch_utils import ALL_LAYERNORM_LAYERS
+from transformers.pytorch_utils import ALL_LAYERNORM_LAYERS #updated to fix this bug , previously it was called from training_args
 from transformers.trainer_utils import seed_worker
 
 if transformers.utils.is_apex_available():


### PR DESCRIPTION
- module ALL_LAYERNORM_LAYERS not found error issue solved
- replaced with from transformers.pytorch_utils import ALL_LAYERNORM_LAYERS