### PR TITLE
Converts `texts` given as a single str to list

### DIFF
--- a/gliner/model.py
+++ b/gliner/model.py
@@ -369,6 +369,8 @@ class GLiNER(nn.Module, PyTorchModelHubMixin):
         """
         self.eval()
         # raw input preparation
+        if isinstance(texts, str):
+            texts = [texts]
         input_x, all_start_token_idx_to_text_idx, all_end_token_idx_to_text_idx = self.prepare_texts(texts)
         
         collator = DataCollator(


### PR DESCRIPTION
Nice work on GLiNER decoder! I was just trying it out but noticed that the example passes `text` as a string:

```python
from gliner import GLiNER

model = GLiNER.from_pretrained("knowledgator/gliner-decoder-large-v1.0")

text = (
    "Apple was founded as Apple Computer Company on April 1, 1976, "
    "by Steve Wozniak, Steve Jobs (1955–2011) and Ronald Wayne to "
    "develop and sell Wozniak's Apple I personal computer."
)

labels = ["person", "other"]

model.run(text, labels, threshold=0.3, num_gen_sequences=1)
```

This results in the string being split into characters. I just added a check to see if `texts` is a string and if so, convert it to a list.