### PR TITLE
fix SpanBiEncoderProcessor label assignment

### DIFF
--- a/gliner/data_processing/processor.py
+++ b/gliner/data_processing/processor.py
@@ -478,7 +478,7 @@ class SpanBiEncoderProcessor(SpanProcessor, BaseBiEncoderProcessor):
             entities = None
         tokenized_input = self.tokenize_inputs(batch['tokens'], entities)
         if prepare_labels:
-            labels = self.create_labels(batch)
+            labels, _ = self.create_labels(batch)
             tokenized_input['labels'] = labels
         return tokenized_input
 


### PR DESCRIPTION
at https://github.com/cceyda/GLiNER/blob/b24538ca86c46e385e1d0e89ad882e52fec74699/gliner/data_processing/processor.py#L388
`create_labels` 
returns a tuple `labels_batch, decoder_tokenized_input`

In `SpanBiEncoderProcessor` there is no need for label decoding stuff so we need to fix the returned value assignment. otherwise labels become tuple & it breaks stuff during forward.