### PR TITLE
classes_to_id is batch metadata and not indexed batch data when entity_labels is passed to DataCollator

### DIFF
--- a/gliner/data_processing/processor.py
+++ b/gliner/data_processing/processor.py
@@ -390,7 +390,10 @@ class SpanProcessor(BaseProcessor):
         decoder_label_strings = []
         for i in range(len(batch['tokens'])):
             tokens = batch['tokens'][i]
-            classes_to_id = batch['classes_to_id']
+            if type(batch['classes_to_id']) == dict:
+                classes_to_id = batch['classes_to_id']
+            elif type(batch['classes_to_id']) == list:
+                classes_to_id = batch['classes_to_id'][i]
             ner = batch['entities'][i]
             num_classes = len(classes_to_id)
             spans_idx = torch.LongTensor([


### PR DESCRIPTION
Closes #298 

The classes_to_id field is incorrectly indexed as a row within the batch.  This causes an index exception.
It is referenced elsewhere as batch metadata like id_to_classes, which is added later in the processing chain.