### PR TITLE
fix(onnx): use explicit max_width in SpanMLP.view() for ONNX export

### DIFF
--- a/gliner/modeling/span_rep.py
+++ b/gliner/modeling/span_rep.py
@@ -75,6 +75,7 @@ class SpanMLP(nn.Module):
         """
         super().__init__()
 
+        self.max_width = max_width
         self.mlp = nn.Linear(hidden_size, hidden_size * max_width)
 
     def forward(self, h, *args):
@@ -95,7 +96,7 @@ class SpanMLP(nn.Module):
 
         span_rep = self.mlp(h)
 
-        span_rep = span_rep.view(B, L, -1, D)
+        span_rep = span_rep.view(B, L, self.max_width, D)
 
         return span_rep.relu()
 


### PR DESCRIPTION
## Summary

Fixes ONNX export failure for models using `SpanMLP` span representation.

The `SpanMLP` class used an inferred dimension (`-1`) in the `view()` call:
```python
span_rep = span_rep.view(B, L, -1, D)
```

This causes ONNX export to fail with a reshape size mismatch error because PyTorch's ONNX exporter cannot reliably infer the `-1` dimension when using dynamic shapes.

**Error example:**
```
total requested size 786432 (dimensions=[1 128 12 512]) doesn't match original size 65536 (dimensions [1 128 512])
```

## Fix

1. Store `max_width` as an instance variable in `__init__`
2. Use `self.max_width` explicitly in `view()` instead of `-1`

```python
# Before
span_rep = span_rep.view(B, L, -1, D)

# After  
span_rep = span_rep.view(B, L, self.max_width, D)
```

This makes `SpanMLP` consistent with other span representation classes (`SpanMarker`, `SpanMarkerV0`, `SpanMarkerV1`) which already use explicit `max_width` in their `view()` calls.

## Testing

- This fix was discovered while attempting to run exported GLiNER ONNX models in [GoMLX](https://github.com/gomlx/gomlx)
- The fix allows successful ONNX export and inference with dynamic batch sizes and sequence lengths