### PR TITLE
Feature/prompt compression

### DIFF
--- a/benchmarks/eval_compressed_biomed.py
+++ b/benchmarks/eval_compressed_biomed.py
@@ -1,0 +1,209 @@
+"""Evaluate raw vs compressed-prompt GLiNER on knowledgator/biomed_NER."""
+
+import argparse
+import random
+import time
+
+import torch
+from datasets import load_dataset
+
+from gliner import GLiNER
+
+
+def predictions_to_ner(text, preds):
+    """Map char-offset predictions from model.inference to word-level ner tuples."""
+    ent_dicts = [{"start": p["start"], "end": p["end"], "class": p["label"]} for p in preds]
+    return char_to_word_sample(text, ent_dicts)
+
+
+def distill_finetune(model, distill_data, *, epochs, lr, batch_size, output_dir):
+    """Fine-tune `model` on pseudo-labeled `distill_data` via GLiNER.train_model."""
+    # Attach the full label set so the collator uses it with prepare_labels=True.
+    model.train_model(
+        train_dataset=distill_data,
+        eval_dataset=None,
+        output_dir=output_dir,
+        num_train_epochs=epochs,
+        max_steps=-1,  # override create_training_args' default (10000) so num_train_epochs wins
+        per_device_train_batch_size=batch_size,
+        learning_rate=lr,
+        save_strategy="no",
+        report_to="none",
+        logging_steps=10,
+        remove_unused_columns=False,
+    )
+    model.eval()
+
+
+def timed_evaluate(model, eval_data, *, warmup, repeats, device, **eval_kwargs):
+    """Run model.evaluate once for metrics and `repeats` times for timing."""
+    if device.startswith("cuda"):
+        torch.cuda.synchronize()
+    out, f1 = model.evaluate(eval_data, **eval_kwargs)
+
+    for _ in range(warmup):
+        model.evaluate(eval_data, **eval_kwargs)
+
+    if device.startswith("cuda"):
+        torch.cuda.synchronize()
+    times = []
+    for _ in range(repeats):
+        t0 = time.perf_counter()
+        model.evaluate(eval_data, **eval_kwargs)
+        if device.startswith("cuda"):
+            torch.cuda.synchronize()
+        times.append(time.perf_counter() - t0)
+
+    mean = sum(times) / len(times)
+    return out, f1, mean, min(times)
+
+
+def char_to_word_sample(text, entities):
+    """Convert {text, entities:[{class,start,end}]} to {tokenized_text, ner}.
+
+    Uses whitespace tokenization and aligns char offsets to word indices.
+    Entities that don't align to word boundaries are dropped.
+    """
+    words = text.split()
+    # Build char-start index for each word (assuming single-space separation of split()).
+    char_starts, char_ends = [], []
+    cursor = 0
+    remaining = text
+    for w in words:
+        idx = remaining.find(w)
+        abs_start = cursor + idx
+        char_starts.append(abs_start)
+        char_ends.append(abs_start + len(w))
+        cursor = abs_start + len(w)
+        remaining = text[cursor:]
+
+    start_to_widx = {s: i for i, s in enumerate(char_starts)}
+    end_to_widx = {e: i for i, e in enumerate(char_ends)}
+
+    ner = []
+    for ent in entities:
+        s, e, cls = ent["start"], ent["end"], ent["class"].lower()
+        # Tolerate leading/trailing whitespace inside span
+        span_text = text[s:e]
+        ls = len(span_text) - len(span_text.lstrip())
+        le = len(span_text) - len(span_text.rstrip())
+        s2, e2 = s + ls, e - le
+        if s2 in start_to_widx and e2 in end_to_widx:
+            ner.append((start_to_widx[s2], end_to_widx[e2], cls))
+    return {"tokenized_text": words, "ner": ner}
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", default="gliner-community/gliner_small-v2.5")
+    parser.add_argument("--dataset", default="knowledgator/biomed_NER")
+    parser.add_argument("--split", default="train")
+    parser.add_argument("--eval_size", type=int, default=3000)
+    parser.add_argument("--compress_size", type=int, default=1000)
+    parser.add_argument("--batch_size", type=int, default=4)
+    parser.add_argument("--threshold", type=float, default=0.5)
+    parser.add_argument("--device", default="cuda:0" if torch.cuda.is_available() else "cpu")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--bench_warmup", type=int, default=1)
+    parser.add_argument("--bench_repeats", type=int, default=1)
+    parser.add_argument("--distill", action="store_true",
+                        help="Fine-tune the compressed model on raw-model pseudo-labels.")
+    parser.add_argument("--distill_size", type=int, default=1000,
+                        help="Number of texts to use for distillation (drawn after compress slice).")
+    parser.add_argument("--distill_epochs", type=int, default=3)
+    parser.add_argument("--distill_lr", type=float, default=1e-5)
+    parser.add_argument("--distill_threshold", type=float, default=0.3)
+    parser.add_argument("--distill_output_dir", type=str, default="./distill_ckpt")
+    args = parser.parse_args()
+
+    random.seed(args.seed)
+
+    print(f"Loading dataset {args.dataset} [{args.split}]...")
+    ds = load_dataset(args.dataset, split=args.split)
+
+    processed = [char_to_word_sample(r["text"], r["entities"]) for r in ds]
+    processed = [p for p in processed if p["ner"]]  # drop empties
+
+    labels = sorted({t for p in processed for _, _, t in p["ner"]})
+    print(f"{len(processed)} samples, {len(labels)} labels: {labels}")
+
+    random.shuffle(processed)
+    # Pin the full label set on every sample so raw and compressed evaluations
+    # share an identical label space. Without this, raw eval would derive
+    # labels per-sample (only the positives present) and be unfairly easier
+    # than the compressed path, which always classifies over all labels.
+    for p in processed:
+        p["ner_labels"] = labels
+    eval_data = processed[: args.eval_size]
+    compress_slice = processed[args.eval_size : args.eval_size + args.compress_size]
+    if not compress_slice:
+        compress_slice = processed[: args.compress_size]
+    compress_texts = [" ".join(p["tokenized_text"]) for p in compress_slice]
+
+    distill_start = args.eval_size + args.compress_size
+    distill_slice = processed[distill_start : distill_start + args.distill_size] if args.distill else []
+
+    print(f"Loading model {args.model}...")
+    model = GLiNER.from_pretrained(args.model).to(args.device)
+
+    eval_kwargs = dict(flat_ner=True, threshold=args.threshold, batch_size=args.batch_size)
+    n = len(eval_data)
+
+    print("=== Raw GLiNER evaluation ===")
+    raw_out, raw_f1, raw_mean, raw_best = timed_evaluate(
+        model, eval_data, warmup=args.bench_warmup, repeats=args.bench_repeats,
+        device=args.device, **eval_kwargs,
+    )
+    print(raw_out)
+    print(f"Raw F1: {raw_f1:.4f}")
+    print(f"Raw timing (n={n}, bs={args.batch_size}, repeats={args.bench_repeats}): "
+          f"mean {raw_mean:.3f}s | best {raw_best:.3f}s | "
+          f"{n / raw_mean:.1f} samples/s")
+
+    distill_data = None
+    if args.distill and distill_slice:
+        print(f"Generating pseudo-labels from raw model on {len(distill_slice)} distillation texts...")
+        distill_texts = [" ".join(p["tokenized_text"]) for p in distill_slice]
+        preds = model.inference(
+            distill_texts, labels, flat_ner=True,
+            threshold=args.distill_threshold, batch_size=args.batch_size,
+        )
+        distill_data = [predictions_to_ner(t, p) for t, p in zip(distill_texts, preds)]
+        kept = sum(1 for d in distill_data if d["ner"])
+        print(f"  {kept}/{len(distill_data)} samples carry at least one pseudo-label")
+
+    print(f"Compressing prompt embeddings over {len(compress_texts)} texts...")
+    model.compress_prompt_embeddings(
+        texts=compress_texts, labels=labels, batch_size=args.batch_size
+    )
+    model.config.precomputed_prompts_mode = True
+
+    if distill_data:
+        print(f"Fine-tuning compressed model on pseudo-labels "
+              f"(epochs={args.distill_epochs}, lr={args.distill_lr})...")
+        distill_finetune(
+            model, distill_data,
+            epochs=args.distill_epochs, lr=args.distill_lr,
+            batch_size=args.batch_size, output_dir=args.distill_output_dir,
+        )
+
+    print("=== Compressed GLiNER evaluation ===")
+    comp_out, comp_f1, comp_mean, comp_best = timed_evaluate(
+        model, eval_data, warmup=args.bench_warmup, repeats=args.bench_repeats,
+        device=args.device, **eval_kwargs,
+    )
+    print(comp_out)
+    print(f"Compressed F1: {comp_f1:.4f}")
+    print(f"Compressed timing (n={n}, bs={args.batch_size}, repeats={args.bench_repeats}): "
+          f"mean {comp_mean:.3f}s | best {comp_best:.3f}s | "
+          f"{n / comp_mean:.1f} samples/s")
+
+    print("\n=== Summary ===")
+    print(f"Raw        F1: {raw_f1:.4f}  | mean {raw_mean:.3f}s | {n / raw_mean:.1f} samples/s")
+    print(f"Compressed F1: {comp_f1:.4f}  | mean {comp_mean:.3f}s | {n / comp_mean:.1f} samples/s")
+    print(f"Delta F1     : {comp_f1 - raw_f1:+.4f}")
+    print(f"Speedup      : {raw_mean / comp_mean:.2f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -990,6 +990,112 @@ print(f"- Products: {[e['text'] for e in entities if e['label'] == 'product']}")
 print(f"- Timeline: {[e['text'] for e in entities if e['label'] == 'date']}")
 ```
 
+## ⚡ Prompt Compression (Precomputed Prompt Embeddings)
+
+For uni-encoder models (span, token, and relation-extraction variants) you can
+precompute the prompt embeddings for a **fixed** label set and reuse them at
+inference time. In precomputed mode the encoder receives only the text
+(no `<<ENT>>label1<<ENT>>...<<SEP>>` prefix), which shortens the input sequence,
+reduces attention cost, and can noticeably speed up inference — at a small
+accuracy trade-off versus re-encoding the prompts on every call.
+
+### How it works
+
+`BaseGLiNER.compress_prompt_embeddings(texts, labels, rel_labels=None, batch_size=8, distill=False, distill_threshold=0.3, distill_epochs=3, distill_lr=1e-5, distill_batch_size=None, distill_output_dir="./distill_ckpt", distill_train_kwargs=None)`:
+
+1. Runs the normal forward pass over `(texts, labels)` pairs.
+2. Extracts the per-label prompt embedding (the `<<ENT>>` token representation,
+   pre-projection) from each example.
+3. Averages across all examples to produce an `(L, D)` matrix stored as a
+   non-trainable parameter on the underlying model (`model.precomputed_prompts`).
+4. Sets `config.precomputed_prompts_mode = True` and writes
+   `config.id_to_classes`, so subsequent `predict_entities` / `forward` calls
+   skip prompt-prepending and look up the stored embeddings instead.
+
+The stored embeddings travel with `state_dict`, so `save_pretrained` /
+`from_pretrained` round-trip them automatically. Training can continue after
+compression — the stored matrix is frozen but everything else keeps training.
+
+### Basic usage (entity extraction)
+
+```python
+from gliner import GLiNER
+
+model = GLiNER.from_pretrained("urchade/gliner_small-v2.1")
+
+# Representative texts from your target domain. They do not need labels;
+# they are only used as contexts while averaging the prompt representations.
+calibration_texts = [
+    "Barack Obama was born in Honolulu, Hawaii.",
+    "Apple announced a new iPhone at their Cupertino headquarters.",
+    # ... ideally 100–1000 diverse sentences from your domain
+]
+
+labels = ["person", "organization", "location", "date"]
+
+# One-time compression step
+model.compress_prompt_embeddings(calibration_texts, labels, batch_size=16)
+
+# Inference now uses the precomputed prompts — no need to pass labels again
+entities = model.predict_entities(
+    "Tim Cook visited Berlin last Tuesday.",
+    labels,               # must match (order-insensitive) the compressed set
+    threshold=0.5,
+)
+
+# Persist the compressed model
+model.save_pretrained("./gliner-compressed")
+```
+
+### Relation extraction
+
+For relex models (`UniEncoderSpanRelexModel` / `UniEncoderTokenRelexModel`),
+pass `rel_labels` so the `<<REL>>` prompt embeddings are compressed as well:
+
+```python
+model.compress_prompt_embeddings(
+    texts=calibration_texts,
+    labels=["person", "organization", "location"],
+    rel_labels=["works_for", "located_in", "founder_of"],
+    batch_size=8,
+)
+```
+
+### End-to-end distillation
+
+Compression alone can dip quality because averaged prompt embeddings drop
+context-specific signal. Pass `distill=True` to recover it in a single call:
+the raw (pre-compression) model first generates pseudo-labels over `texts`,
+prompts are then compressed, and the compressed model is fine-tuned on those
+pseudo-labels — no separate script required.
+
+```python
+model.compress_prompt_embeddings(
+    texts=calibration_texts,     # also used as the distillation corpus
+    labels=labels,
+    batch_size=16,
+    distill=True,
+    distill_threshold=0.3,       # pseudo-label confidence cutoff
+    distill_epochs=3,
+    distill_lr=1e-5,
+    distill_output_dir="./distill_ckpt",
+)
+```
+
+Relevant knobs:
+
+- `distill_threshold`: confidence cutoff used when the raw model produces
+  pseudo-labels. Lower values widen the training signal but add noise.
+- `distill_epochs`, `distill_lr`: fine-tuning schedule.
+- `distill_batch_size`: defaults to `batch_size` if omitted.
+- `distill_output_dir`: forwarded to `train_model`.
+- `distill_train_kwargs`: dict of extra kwargs merged into the underlying
+  `train_model` call (e.g. to override `save_strategy`, `logging_steps`, etc.).
+
+Pseudo-labels are generated from the same `texts` used for compression, so one
+diverse in-domain corpus serves both roles.
+
+
 ## Tips and Best Practices
 
 1. **Choose the right model architecture**:

--- a/gliner/config.py
+++ b/gliner/config.py
@@ -39,6 +39,8 @@ class BaseGLiNERConfig(PretrainedConfig):
         span_loss_coef: float = 1.0,
         represent_spans: bool = False,
         neg_spans_ratio: float = 1.0,
+        precomputed_prompts_mode: Optional[bool] = None,
+        id_to_classes: Optional[dict] = None,
         **kwargs,
     ):
         """Initialize BaseGLiNERConfig.
@@ -72,6 +74,8 @@ class BaseGLiNERConfig(PretrainedConfig):
             span_loss_coef (float, optional): Span loss coefficient. Defaults to 1.0.
             represent_spans (bool, optional): Whether to represent spans. Defaults to False.
             neg_spans_ratio (float, optional): Ratio of negative spans. Defaults to 1.0.
+            precomputed_prompts_mode (Optional[bool]): Whether to use precomputed prompts. Defaults to None.
+            id_to_classes (Optional[dict]): Mapping from class IDs to class names. Defaults to None.
             **kwargs: Additional keyword arguments passed to parent class.
         """
         super().__init__(**kwargs)
@@ -108,6 +112,8 @@ class BaseGLiNERConfig(PretrainedConfig):
         self.span_loss_coef = span_loss_coef
         self.represent_spans = represent_spans
         self.neg_spans_ratio = neg_spans_ratio
+        self.precomputed_prompts_mode = precomputed_prompts_mode
+        self.id_to_classes = id_to_classes
 
 
 class UniEncoderConfig(BaseGLiNERConfig):
@@ -201,6 +207,7 @@ class UniEncoderRelexConfig(UniEncoderConfig):
         augment_ent_drop_prob=(0.0, 1.0),
         augment_rel_drop_prob=(0.0, 0.3),
         augment_add_other_prob=0.5,
+        rel_id_to_classes: Optional[dict] = None,
         **kwargs,
     ):
         """Initialize UniEncoderRelexConfig.
@@ -223,6 +230,7 @@ class UniEncoderRelexConfig(UniEncoderConfig):
                 the per-type entity drop probability. Defaults to (0.0, 0.4).
             augment_rel_drop_prob (tuple, optional): Range (min, max) from which to sample
                 the per-type relation drop probability. Defaults to (0.0, 0.4).
+            rel_id_to_classes (Optional[dict]): Mapping from relation class IDs to class names. Defaults to None.
             **kwargs: Additional keyword arguments passed to UniEncoderConfig.
 
         Raises:
@@ -241,6 +249,7 @@ class UniEncoderRelexConfig(UniEncoderConfig):
         self.augment_ent_drop_prob = tuple(augment_ent_drop_prob)
         self.augment_rel_drop_prob = tuple(augment_rel_drop_prob)
         self.augment_add_other_prob = augment_add_other_prob
+        self.rel_id_to_classes = rel_id_to_classes
 
 
 class UniEncoderSpanRelexConfig(UniEncoderRelexConfig):

--- a/gliner/data_processing/processor.py
+++ b/gliner/data_processing/processor.py
@@ -179,7 +179,15 @@ class BaseProcessor(ABC):
         input_texts: List[List[str]] = []
         prompt_lengths: List[int] = []
 
+        skip_prompt = getattr(self.config, "precomputed_prompts_mode", False)
+
         for i, text in enumerate(texts):
+            if skip_prompt:
+                prompt = [self.sep_token]
+                prompt_lengths.append(len(prompt))
+                input_texts.append(prompt + list(text))
+                continue
+
             ents = self._select_entities(i, entities, blank)
 
             ents = self._maybe_remap_entities(ents)
@@ -373,6 +381,20 @@ class BaseProcessor(ABC):
         Returns:
             Dictionary containing collated batch data ready for model input.
         """
+        if getattr(self.config, "precomputed_prompts_mode", False) and class_to_ids is None:
+            # In precomputed mode, the label set is fixed by compress_prompt_embeddings
+            # and stored on the config. Reuse it for every batch instead of
+            # re-deriving per-sample mappings.
+            fixed = getattr(self.config, "id_to_classes", None)
+            if fixed:
+                shared_id_to_classes = dict(fixed)
+                shared_class_to_ids = {v: k for k, v in shared_id_to_classes.items()}
+                # Downstream code (create_labels, create_batch_dict) indexes
+                # these by sample, so replicate the shared mapping per sample.
+                class_to_ids = [shared_class_to_ids for _ in batch_list]
+                id_to_classes = [shared_id_to_classes for _ in batch_list]
+                entity_types = None
+
         if class_to_ids is None and entity_types is None:
             # Dynamically infer per-example mappings
             class_to_ids, id_to_classes = self.batch_generate_class_mappings(batch_list, negatives)
@@ -2026,7 +2048,15 @@ class RelationExtractionSpanProcessor(UniEncoderSpanProcessor):
         input_texts: List[List[str]] = []
         prompt_lengths: List[int] = []
 
+        skip_prompt = getattr(self.config, "precomputed_prompts_mode", False)
+
         for i, text in enumerate(texts):
+            if skip_prompt:
+                prompt = [self.sep_token]
+                prompt_lengths.append(len(prompt))
+                input_texts.append(prompt + list(text))
+                continue
+
             ents = self._select_entities(i, entities, blank)
             ents = self._maybe_remap_entities(ents)
 

--- a/gliner/evaluation/evaluator.py
+++ b/gliner/evaluation/evaluator.py
@@ -166,7 +166,10 @@ class BaseNEREvaluator(BaseEvaluator):
         """
         all_ents = []
         for ent in ents:
-            all_ents.append([ent[2], (ent[0], ent[1])])
+            if hasattr(ent, "start"):
+                all_ents.append([ent.entity_type, (ent.start, ent.end)])
+            else:
+                all_ents.append([ent[2], (ent[0], ent[1])])
         return all_ents
 
     def transform_data(self):

--- a/gliner/model.py
+++ b/gliner/model.py
@@ -69,6 +69,7 @@ from .modeling.base import (
     UniEncoderSpanDecoderModel,
     UniEncoderTokenDecoderModel,
 )
+from .modeling.utils import extract_prompt_features
 from .data_processing import (
     BaseProcessor,
     BiEncoderSpanProcessor,
@@ -1715,6 +1716,7 @@ class BaseEncoderGLiNER(BaseGLiNER):
             **kwargs,
         )
 
+    @torch.no_grad()
     def evaluate(
         self,
         test_data: List[Dict[str, Any]],
@@ -1760,6 +1762,124 @@ class BaseEncoderGLiNER(BaseGLiNER):
         out, f1 = evaluator.evaluate()
 
         return out, f1
+
+    @torch.no_grad()
+    def compress_prompt_embeddings(
+        self,
+        texts: List[str],
+        labels: List[str],
+        rel_labels: Optional[List[str]] = None,
+        batch_size: int = 8,
+    ) -> None:
+        """Precompute averaged prompt embeddings for each label.
+
+        Runs the normal forward pass over (texts, labels) pairs, extracts the
+        per-label prompt embedding from each example, and stores the mean per
+        label on the underlying model. Sets ``config.precomputed_prompts_mode``
+        to True so subsequent inference/training will skip label-prepending and
+        look up the stored embeddings instead. Relation labels are supported for
+        relation-extraction models via ``rel_labels``.
+
+        Args:
+            texts: List of raw input texts used as contexts for averaging.
+            labels: Entity labels to compress.
+            rel_labels: Optional relation labels (relex models only).
+            batch_size: Batch size used while running the model.
+        """
+        if not texts or not labels:
+            raise ValueError("`texts` and `labels` must both be non-empty.")
+
+        self.eval()
+        device = self.device
+        D = self.config.hidden_size
+
+        # Force the normal (non-precomputed) code path while we compute the stats.
+        prev_mode = getattr(self.config, "precomputed_prompts_mode", None)
+        self.config.precomputed_prompts_mode = False
+        try:
+            labels = list(dict.fromkeys(labels))
+            rel_labels = list(dict.fromkeys(rel_labels)) if rel_labels else None
+
+            L = len(labels)
+            L_rel = len(rel_labels) if rel_labels else 0
+            ent_sum = torch.zeros(L, D, device=device)
+            rel_sum = torch.zeros(L_rel, D, device=device) if L_rel else None
+
+            tokens, _, _ = self.prepare_inputs(texts)
+            input_x = self.prepare_base_input(tokens)
+
+            collator_kwargs = dict(
+                return_tokens=True,
+                return_entities=True,
+                return_id_to_classes=True,
+                prepare_labels=False,
+            )
+            if rel_labels is not None:
+                collator_kwargs["return_rel_id_to_classes"] = True
+
+            collator = self.data_collator_class(
+                self.config, data_processor=self.data_processor, **collator_kwargs
+            )
+
+            def collate_fn(batch):
+                if rel_labels is not None:
+                    return collator(batch, entity_types=labels, relation_types=rel_labels)
+                return collator(batch, entity_types=labels)
+
+            loader = DataLoader(
+                input_x, batch_size=batch_size, shuffle=False, collate_fn=collate_fn
+            )
+
+            for batch in tqdm(loader, desc="Compressing prompts"):
+                batch_gpu = {
+                    k: (v.to(device) if isinstance(v, torch.Tensor) else v)
+                    for k, v in batch.items()
+                }
+                input_ids = batch_gpu["input_ids"]
+                attention_mask = batch_gpu["attention_mask"]
+
+                # Encode once; pull pre-projection prompt embeddings directly.
+                token_embeds = self.model.token_rep_layer(input_ids, attention_mask)
+                batch_size_e, _, embed_dim_e = token_embeds.shape
+
+                prompts_emb, _ = extract_prompt_features(
+                    self.config.class_token_index,
+                    token_embeds,
+                    input_ids,
+                    attention_mask,
+                    batch_size_e,
+                    embed_dim_e,
+                    self.config.embed_ent_token,
+                )
+                # prompts_emb is (B, L, D) in the canonical `labels` order since we
+                ent_sum = ent_sum + prompts_emb.detach().sum(dim=0).to(device)
+
+                if rel_labels is not None and getattr(self.config, "rel_token_index", None) is not None:
+                    rel_emb, _ = extract_prompt_features(
+                        self.config.rel_token_index,
+                        token_embeds,
+                        input_ids,
+                        attention_mask,
+                        batch_size_e,
+                        embed_dim_e,
+                        self.config.embed_rel_token,
+                    )
+                    rel_sum = rel_sum + rel_emb.detach().sum(dim=0).to(device)
+
+            avg = ent_sum / len(texts)
+            self.model.set_precomputed_prompts(labels, avg, rel=False)
+            self.config.id_to_classes = {i + 1: l for i, l in enumerate(labels)}
+
+            if rel_labels is not None:
+                rel_avg = rel_sum / len(texts)
+                self.model.set_precomputed_prompts(rel_labels, rel_avg, rel=True)
+                self.config.rel_id_to_classes = {i + 1: l for i, l in enumerate(rel_labels)}
+
+        except Exception:
+            self.config.precomputed_prompts_mode = prev_mode
+            raise
+
+        self.config.precomputed_prompts_mode = True
 
 
 class BaseBiEncoderGLiNER(BaseEncoderGLiNER):
@@ -2847,6 +2967,7 @@ class UniEncoderSpanRelexGLiNER(BaseEncoderGLiNER):
 
         return all_relations
 
+    @torch.no_grad()
     def evaluate(
         self,
         test_data: List[Dict[str, Any]],

--- a/gliner/model.py
+++ b/gliner/model.py
@@ -1763,13 +1763,19 @@ class BaseEncoderGLiNER(BaseGLiNER):
 
         return out, f1
 
-    @torch.no_grad()
     def compress_prompt_embeddings(
         self,
         texts: List[str],
         labels: List[str],
         rel_labels: Optional[List[str]] = None,
         batch_size: int = 8,
+        distill: bool = False,
+        distill_threshold: float = 0.3,
+        distill_epochs: int = 3,
+        distill_lr: float = 1e-5,
+        distill_batch_size: Optional[int] = None,
+        distill_output_dir: str = "./distill_ckpt",
+        distill_train_kwargs: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Precompute averaged prompt embeddings for each label.
 
@@ -1780,15 +1786,102 @@ class BaseEncoderGLiNER(BaseGLiNER):
         look up the stored embeddings instead. Relation labels are supported for
         relation-extraction models via ``rel_labels``.
 
+        When ``distill=True``, the raw (pre-compression) model first generates
+        pseudo-labels over ``texts``; the method then compresses prompt
+        embeddings and fine-tunes the compressed model on those pseudo-labels
+        so quality recovers end-to-end in a single call.
+
         Args:
             texts: List of raw input texts used as contexts for averaging.
             labels: Entity labels to compress.
             rel_labels: Optional relation labels (relex models only).
             batch_size: Batch size used while running the model.
+            distill: If True, generate pseudo-labels with the raw model over
+                ``texts`` and fine-tune the compressed model on them.
+            distill_threshold: Confidence threshold for pseudo-label generation.
+            distill_epochs: Number of fine-tuning epochs.
+            distill_lr: Fine-tuning learning rate.
+            distill_batch_size: Batch size for fine-tuning (defaults to ``batch_size``).
+            distill_output_dir: Output directory passed to ``train_model``.
+            distill_train_kwargs: Extra kwargs forwarded to ``train_model``.
         """
         if not texts or not labels:
             raise ValueError("`texts` and `labels` must both be non-empty.")
 
+        distill_data = None
+        if distill:
+            self.eval()
+            with torch.no_grad():
+                preds = self.inference(
+                    texts, labels, flat_ner=True,
+                    threshold=distill_threshold, batch_size=batch_size,
+                )
+            distill_data = [
+                self._predictions_to_word_level(t, p) for t, p in zip(texts, preds)
+            ]
+            for sample in distill_data:
+                sample["ner_labels"] = labels
+
+        self._compute_prompt_embeddings(
+            texts=texts, labels=labels, rel_labels=rel_labels, batch_size=batch_size,
+        )
+
+        if distill_data:
+            train_kwargs = {
+                "num_train_epochs": distill_epochs,
+                "max_steps": -1,
+                "per_device_train_batch_size": distill_batch_size or batch_size,
+                "learning_rate": distill_lr,
+                "save_strategy": "no",
+                "report_to": "none",
+                "logging_steps": 10,
+                "remove_unused_columns": False,
+            }
+            if distill_train_kwargs:
+                train_kwargs.update(distill_train_kwargs)
+            self.train_model(
+                train_dataset=distill_data,
+                eval_dataset=None,
+                output_dir=distill_output_dir,
+                **train_kwargs,
+            )
+            self.eval()
+
+    @staticmethod
+    def _predictions_to_word_level(text: str, preds: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """Convert char-offset predictions to whitespace-word-level NER format."""
+        words = text.split()
+        char_starts, char_ends = [], []
+        cursor = 0
+        remaining = text
+        for w in words:
+            idx = remaining.find(w)
+            abs_start = cursor + idx
+            char_starts.append(abs_start)
+            char_ends.append(abs_start + len(w))
+            cursor = abs_start + len(w)
+            remaining = text[cursor:]
+        start_to_widx = {s: i for i, s in enumerate(char_starts)}
+        end_to_widx = {e: i for i, e in enumerate(char_ends)}
+        ner = []
+        for p in preds:
+            s, e, cls = p["start"], p["end"], p["label"].lower()
+            span_text = text[s:e]
+            ls = len(span_text) - len(span_text.lstrip())
+            le = len(span_text) - len(span_text.rstrip())
+            s2, e2 = s + ls, e - le
+            if s2 in start_to_widx and e2 in end_to_widx:
+                ner.append((start_to_widx[s2], end_to_widx[e2], cls))
+        return {"tokenized_text": words, "ner": ner}
+
+    @torch.no_grad()
+    def _compute_prompt_embeddings(
+        self,
+        texts: List[str],
+        labels: List[str],
+        rel_labels: Optional[List[str]] = None,
+        batch_size: int = 8,
+    ) -> None:
         self.eval()
         device = self.device
         D = self.config.hidden_size

--- a/gliner/modeling/base.py
+++ b/gliner/modeling/base.py
@@ -74,6 +74,54 @@ class BaseModel(ABC, nn.Module):
         self.config = config
         self.from_pretrained = from_pretrained
         self.cache_dir = cache_dir
+        # Precomputed prompt storage. Populated via compress_prompt_embeddings.
+        self.register_parameter("precomputed_prompts", None)
+        self.register_parameter("precomputed_rel_prompts", None)
+        self._precomputed_labels: list = []
+        self._precomputed_rel_labels: list = []
+
+    def set_precomputed_prompts(
+        self, labels: list, embeddings: torch.Tensor, rel: bool = False
+    ) -> None:
+        """Store averaged prompt embeddings keyed by label name.
+
+        Args:
+            labels: Ordered list of label names (length N).
+            embeddings: Tensor of shape (N, D) with one embedding per label.
+            rel: If True, store as relation prompts, otherwise entity prompts.
+        """
+        param_name = "precomputed_rel_prompts" if rel else "precomputed_prompts"
+        labels_attr = "_precomputed_rel_labels" if rel else "_precomputed_labels"
+        param = nn.Parameter(embeddings.detach().clone(), requires_grad=False)
+        # Replace existing parameter safely.
+        if param_name in self._parameters:
+            del self._parameters[param_name]
+        self.register_parameter(param_name, param)
+        setattr(self, labels_attr, list(labels))
+
+    def lookup_precomputed_prompts(
+        self,
+        batch_size: int,
+        device: torch.device,
+        rel: bool = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Return precomputed prompts as (B, L, D) with an all-ones (B, L) mask.
+
+        The stored (L, D) matrix is built once by ``compress_prompt_embeddings``
+        in a canonical label order; inference just expands it to the batch size.
+        """
+        param_name = "precomputed_rel_prompts" if rel else "precomputed_prompts"
+        stored: Optional[torch.Tensor] = getattr(self, param_name)
+        if stored is None:
+            raise RuntimeError(
+                f"Precomputed prompts not initialised (attr={param_name}). "
+                f"Call compress_prompt_embeddings first."
+            )
+        stored_dev = stored.to(device) if stored.device != device else stored
+        L = stored_dev.size(0)
+        out = stored_dev.unsqueeze(0).expand(batch_size, -1, -1)
+        mask = torch.ones(batch_size, L, dtype=torch.long, device=device)
+        return out, mask
 
     @abstractmethod
     def get_representations(self) -> Tuple[torch.Tensor, ...]:
@@ -308,11 +356,25 @@ class BaseUniEncoderModel(BaseModel):
         """
         token_embeds = self.token_rep_layer(input_ids, attention_mask, **kwargs)
 
-        prompts_embedding, prompts_embedding_mask, words_embedding, mask = (
-            self._extract_prompt_features_and_word_embeddings(
-                token_embeds, input_ids, attention_mask, text_lengths, words_mask
-            )
+        use_precomputed = (
+            getattr(self.config, "precomputed_prompts_mode", False)
+            and getattr(self, "precomputed_prompts", None) is not None
         )
+        if use_precomputed:
+            batch_size, _, embed_dim = token_embeds.shape
+            max_text_length = text_lengths.max()
+            words_embedding, mask = extract_word_embeddings(
+                token_embeds, words_mask, attention_mask, batch_size, max_text_length, embed_dim, text_lengths
+            )
+            prompts_embedding, prompts_embedding_mask = self.lookup_precomputed_prompts(
+                batch_size, device=token_embeds.device, rel=False
+            )
+        else:
+            prompts_embedding, prompts_embedding_mask, words_embedding, mask = (
+                self._extract_prompt_features_and_word_embeddings(
+                    token_embeds, input_ids, attention_mask, text_lengths, words_mask
+                )
+            )
 
         if hasattr(self, "rnn"):
             words_embedding = self.rnn(words_embedding, mask)
@@ -2200,11 +2262,26 @@ class UniEncoderSpanRelexModel(UniEncoderSpanModel):
 
         token_embeds = self.token_rep_layer(input_ids, attention_mask, **encoder_kwargs)
 
-        prompts_embedding, prompts_embedding_mask, words_embedding, mask = (
-            self._extract_prompt_features_and_word_embeddings(
-                token_embeds, input_ids, attention_mask, text_lengths, words_mask
-            )
+        use_precomputed = (
+            getattr(self.config, "precomputed_prompts_mode", False)
+            and getattr(self, "precomputed_prompts", None) is not None
         )
+        if use_precomputed:
+            batch_size_e, _, embed_dim_e = token_embeds.shape
+            max_text_length = text_lengths.max()
+            words_embedding, mask = extract_word_embeddings(
+                token_embeds, words_mask, attention_mask,
+                batch_size_e, max_text_length, embed_dim_e, text_lengths,
+            )
+            prompts_embedding, prompts_embedding_mask = self.lookup_precomputed_prompts(
+                batch_size_e, device=token_embeds.device, rel=False
+            )
+        else:
+            prompts_embedding, prompts_embedding_mask, words_embedding, mask = (
+                self._extract_prompt_features_and_word_embeddings(
+                    token_embeds, input_ids, attention_mask, text_lengths, words_mask
+                )
+            )
 
         if hasattr(self, "rnn"):
             words_embedding = self.rnn(words_embedding, mask)
@@ -2236,7 +2313,7 @@ class UniEncoderSpanRelexModel(UniEncoderSpanModel):
         )
 
         pair_idx, pair_mask, pair_scores = None, None, None
-        rel_prompts_embedding_mask = None
+        rel_prompts_embedding , rel_prompts_embedding_mask = None, None
         pred_adj_matrix = None
 
         has_relex = hasattr(self, "relations_rep_layer") or hasattr(self, "pair_rep_layer") or hasattr(self, "triples_score_layer")
@@ -2245,15 +2322,20 @@ class UniEncoderSpanRelexModel(UniEncoderSpanModel):
             if hasattr(self, "relations_rep_layer"):
                 pred_adj_matrix = self.relations_rep_layer(target_span_rep, target_span_mask)
 
-            rel_prompts_embedding, rel_prompts_embedding_mask = extract_prompt_features(
-                self.config.rel_token_index,
-                token_embeds,
-                input_ids,
-                attention_mask,
-                batch_size,
-                embed_dim,
-                self.config.embed_rel_token,
-            )
+            if use_precomputed and getattr(self, "precomputed_rel_prompts", None) is not None:
+                rel_prompts_embedding, rel_prompts_embedding_mask = self.lookup_precomputed_prompts(
+                    batch_size, device=token_embeds.device, rel=True
+                )
+            else:
+                rel_prompts_embedding, rel_prompts_embedding_mask = extract_prompt_features(
+                    self.config.rel_token_index,
+                    token_embeds,
+                    input_ids,
+                    attention_mask,
+                    batch_size,
+                    embed_dim,
+                    self.config.embed_rel_token,
+                )
 
             B, _, D = target_span_rep.shape
             C_rel = rel_prompts_embedding.size(1)
@@ -2354,6 +2436,8 @@ class UniEncoderSpanRelexModel(UniEncoderSpanModel):
             rel_idx=None if is_training else pair_idx,
             rel_logits=None if is_training else pair_scores,
             rel_mask=None if is_training else pair_mask,
+            rel_prompts_embedding=rel_prompts_embedding,
+            rel_prompts_embedding_mask=rel_prompts_embedding_mask,
             entity_spans=None if is_training else entity_spans,
         )
         return output

--- a/gliner/modeling/outputs.py
+++ b/gliner/modeling/outputs.py
@@ -94,9 +94,15 @@ class GLiNERRelexOutput(GLiNERBaseOutput):
             relations between entity pairs. Shape: [batch_size, num_relations, num_relation_types].
         rel_mask (Optional[torch.FloatTensor]): Mask indicating valid relation
             predictions. Shape: [batch_size, num_relations].
+        rel_prompts_embedding (Optional[torch.FloatTensor]): Embeddings for
+            relation type prompts/labels. Shape: [batch_size, num_relation_types, hidden_size].
+        rel_prompts_embedding_mask (Optional[torch.LongTensor]): Attention mask
+            for relation prompt embeddings. Shape: [batch_size, num_relation_types].
     """
 
     rel_idx: Optional[torch.LongTensor] = None
     rel_logits: Optional[torch.FloatTensor] = None
     rel_mask: Optional[torch.FloatTensor] = None
     entity_spans: Optional[torch.LongTensor] = None
+    rel_prompts_embedding: Optional[torch.FloatTensor] = None
+    rel_prompts_embedding_mask: Optional[torch.LongTensor] = None


### PR DESCRIPTION
# Summary                                                                                                                                                                               
                                          
  Introduces prompt compression for uni-encoder GLiNER models (span, token, and relation-extraction variants). For a fixed label set, prompt embeddings are computed once and reused at inference — the encoder no longer re-processes the <<ENT>>label1<<ENT>>...<<SEP>> prefix on every call, shortening the input sequence and cutting attention cost for a meaningful speedup, especially for short sequences.
                                                                                                                                                                                        
 # What's included                             
                                                                                                                                                                                        
  - BaseGLiNER.compress_prompt_embeddings(texts, labels, rel_labels=None, batch_size=8, ...) — runs a forward pass over a calibration corpus, extracts the pre-projection <<ENT>> (and optionally <<REL>>) token representations, averages them per label, and stores the resulting (L, D) matrix as a non-trainable parameter on the underlying model.                      
  - Precomputed inference path — config.precomputed_prompts_mode=True switches forward / predict_entities to look up the stored embeddings instead of prepending label tokens. State travels through state_dict, so save_pretrained / from_pretrained round-trip the compressed model automatically.                                                                       
  - Relation-extraction support — pass rel_labels=... to compress <<REL>> prompts for relex models alongside entities.
  - End-to-end distillation (opt-in) — distill=True makes compress_prompt_embeddings a one-call pipeline: the pre-compression model first generates pseudo-labels over texts, prompts  are compressed, and the compressed model is fine-tuned on those pseudo-labels to recover the small accuracy drop from averaging. Exposes distill_threshold, distill_epochs,           
  distill_lr, distill_batch_size, distill_output_dir, and distill_train_kwargs for control.
  - Benchmark script — benchmarks/eval_compressed_biomed.py compares raw vs. compressed (optionally distilled) GLiNER on knowledgator/biomed_NER, reporting F1, latency, and speedup.   
  - Docs — docs/usage.md gains a "⚡ Prompt Compression" section covering the basic flow, relation extraction, and end-to-end distillation.                                             
                                                                                                                                                                                        
 # Usage                                                                                                                                                                                 
 ```python                                                                                                                                                               
  model = GLiNER.from_pretrained("urchade/gliner_small-v2.1")                                                                                                                           
                                                                                                                                                                                        
  # One-call compression + distillation                                                                                                                                                 
  model.compress_prompt_embeddings(
      texts=calibration_texts,                                                                                                                                                          
      labels=["person", "organization", "location", "date"],
      batch_size=16,                                                                                                                                                                    
      distill=True,                       
      distill_epochs=3,
  )                                                                                                                                                                                     
                                              
  model.save_pretrained("./gliner-compressed")                                                                                                                                          
  ```
  # Trade-offs                                                                                                                                                                            
                                          
  - Label set becomes fixed per compressed model — adding labels requires re-running compression.                                                                                       
  - Prompt averaging loses some context sensitivity; enabling distill=True typically recovers it.                                                                                       
  - Applies to uni-encoder variants only (bi-encoder already uses a separate label encoder).