### PR TITLE
Deprecate pure-downcast paths in `quantize(...)`

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -394,7 +394,7 @@ Accepted values: `"fp16"` / `"float16"` / `"half"`, `"bf16"` / `"bfloat16"`, `"f
 
 ### Quantization, Compilation & FlashDeBERTa
 
-Use `quantize=True` and `compile_torch_model=True` for up to ~1.9x faster GPU inference with zero quality loss:
+Combine `dtype="fp16"` (or `"bf16"`) with `compile_torch_model=True` for up to ~1.9x faster GPU inference with zero quality loss:
 
 ```python
 from gliner import GLiNER
@@ -402,7 +402,7 @@ from gliner import GLiNER
 model = GLiNER.from_pretrained(
     "urchade/gliner_medium-v2.1",
     map_location="cuda",
-    quantize=True,            # or "fp16", "bf16"
+    dtype="fp16",             # or "bf16" — see "Reduced-precision loading" above
     compile_torch_model=True,
 )
 ```
@@ -410,9 +410,9 @@ model = GLiNER.from_pretrained(
 Or apply after loading:
 
 ```python
+import torch
 model = GLiNER.from_pretrained("urchade/gliner_medium-v2.1", map_location="cuda")
-model.quantize()         # fp16 half-precision (default)
-model.quantize("bf16")   # bfloat16 — better numerical stability, slightly less speedup
+model.to(torch.float16)  # fp16 half-precision
 model.compile()          # torch.compile with dynamic shapes
 ```
 
@@ -423,15 +423,15 @@ Compilation is especially beneficial for short sequences, where the overhead of 
 | Condition | F1 | Speedup |
 |-----------|:---:|:---:|
 | GPU fp32 (baseline) | 0.8107 | 1.00x |
-| + quantize (fp16) | 0.8107 | 1.35x |
+| + `dtype="fp16"` | 0.8107 | 1.35x |
 | + compile | 0.8107 | 1.31x |
-| **+ quantize + compile** | **0.8107** | **1.94x** |
+| **+ `dtype="fp16"` + compile** | **0.8107** | **1.94x** |
 
-**Quantization options:**
-- `quantize=True` or `quantize="fp16"` — float16 half-precision. Best GPU speedup (~1.35x).
-- `quantize="bf16"` — bfloat16. Better numerical stability, slightly less speedup (~1.2x).
-- `quantize="int8"` — int8 quantization. On CPU, uses built-in FBGEMM int8 kernels (~1.6x speedup). On GPU, uses [torchao](https://github.com/pytorch/ao) int8 weight-only quantization (~50% memory reduction, no speed gain). Intended for models fine-tuned with quantization-aware training (QAT). Stock DeBERTa-based models lose accuracy with int8.
-- On CPU, fp16/bf16 quantization reduces memory usage but does not improve speed.
+**`quantize=` vs `dtype=`:**
+- `dtype="fp16"` / `"bf16"` — plain precision change via efficient load (see the dedicated section above). This is the recommended way to get half-precision inference.
+- `quantize="int8"` — real int8 quantization. On CPU, built-in FBGEMM kernels (~1.6x speedup). On GPU, [torchao](https://github.com/pytorch/ao) int8 weight-only quantization (~50% memory reduction, no speed gain). Intended for models fine-tuned with quantization-aware training (QAT); stock DeBERTa-based models lose accuracy with int8.
+- `quantize=True` / `"fp16"` / `"bf16"` — **deprecated** for precision-only changes on GPU (and for `"bf16"` on CPU) because these paths are just a downcast with an extra fp32 intermediate. They still work and emit a `DeprecationWarning` pointing at `dtype=`. `quantize="fp16"` on CPU is preserved as the only non-deprecated path there — it performs real dynamic quantization of `nn.Linear` layers (reduces memory, no speed benefit).
+- Passing both `dtype=` and a downcast `quantize=` emits a warning because `quantize` runs after the load and will overwrite the precision.
 
 **Compilation notes:**
 - `compile_torch_model=True` uses [torch.compile](https://pytorch.org/docs/stable/torch.compiler.html) which JIT-compiles the model via [Triton](https://github.com/triton-lang/triton) kernels. The first inference call will be slower due to compilation, but all subsequent calls benefit from the compiled graph. This is only available on **Linux and WSL** (not native Windows or macOS).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -366,6 +366,32 @@ model = GLiNER.from_pretrained(
 print(f"Model is on: {model.device}")
 ```
 
+### Reduced-precision loading (`dtype`)
+
+Pass `dtype` to `from_pretrained` to load the weights directly at the target floating-point precision — no intermediate fp32 copy, no post-load cast:
+
+```python
+from gliner import GLiNER
+import torch
+
+# Either a string or a torch.dtype
+model = GLiNER.from_pretrained("urchade/gliner_medium-v2.1", dtype="bf16", map_location="cuda")
+model = GLiNER.from_pretrained("urchade/gliner_medium-v2.1", dtype=torch.bfloat16, map_location="cuda")
+```
+
+Accepted values: `"fp16"` / `"float16"` / `"half"`, `"bf16"` / `"bfloat16"`, `"fp32"` / `"float32"` / `"float"`, or any `torch.dtype`. Int/bool buffers are left untouched.
+
+**Why use `dtype` instead of `quantize="bf16"`:**
+- `quantize` casts *after* the full fp32 state dict + fp32 model are already in memory.
+- `dtype` casts each tensor *as it is read* from the safetensors file and pre-casts the model shell before `load_state_dict`, so the fp32 copy is never fully materialized. Peak host memory during load drops from ~2× fp32 to ~1× fp32 for bf16/fp16, and the separate cast pass is skipped.
+
+**When it matters:** cold starts and scalable serverless deployments (AWS Lambda, Cloud Run, Modal, RunPod serverless, autoscaled Kubernetes pods, etc.) — startup latency and peak memory directly drive cost and SLA:
+- Shorter cold-start on every new container (one pass instead of load + cast).
+- Lower peak memory lets instances fit on smaller memory tiers and reduces boot-time OOMs under memory pressure.
+- Faster first-inference latency after a scale-from-zero event.
+
+`dtype` covers plain precision changes (bf16/fp16/fp32). For int8 / torchao / CPU dynamic quantization, keep using `quantize` (see below). The two can be combined if desired.
+
 ### Quantization, Compilation & FlashDeBERTa
 
 Use `quantize=True` and `compile_torch_model=True` for up to ~1.9x faster GPU inference with zero quality loss:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -379,11 +379,11 @@ model = GLiNER.from_pretrained("urchade/gliner_medium-v2.1", dtype="bf16", map_l
 model = GLiNER.from_pretrained("urchade/gliner_medium-v2.1", dtype=torch.bfloat16, map_location="cuda")
 ```
 
-Accepted values: `"fp16"` / `"float16"` / `"half"`, `"bf16"` / `"bfloat16"`, `"fp32"` / `"float32"` / `"float"`, or any `torch.dtype`. Int/bool buffers are left untouched.
+Accepted values: `"fp16"` / `"float16"` / `"half"`, `"bf16"` / `"bfloat16"`, `"fp32"` / `"float32"` / `"float"`, or any floating-point `torch.dtype`. Int/bool buffers are left untouched; non-floating dtypes (e.g. `torch.int8`) are rejected — use `quantize="int8"` for that path.
 
 **Why use `dtype` instead of `quantize="bf16"`:**
 - `quantize` casts *after* the full fp32 state dict + fp32 model are already in memory.
-- `dtype` casts each tensor *as it is read* from the safetensors file and pre-casts the model shell before `load_state_dict`, so the fp32 copy is never fully materialized. Peak host memory during load drops from ~2× fp32 to ~1× fp32 for bf16/fp16, and the separate cast pass is skipped.
+- `dtype` casts each tensor *as it is read* from the safetensors file and pre-casts the model shell before `load_state_dict`, so a fully-fp32 snapshot never co-exists with the loaded weights. For CPU-only loads, peak host memory during load drops from ~2× fp32 to ~1× fp32 for bf16/fp16. For `map_location="cuda"`, the state dict streams to GPU while the shell is CPU-side, so the saving is avoiding a simultaneous fp32 GPU state dict + fp32 GPU model — not quite a 2×→1× total-footprint reduction, but still a meaningful win on the GPU peak and on the separate post-load cast pass.
 
 **When it matters:** cold starts and scalable serverless deployments (AWS Lambda, Cloud Run, Modal, RunPod serverless, autoscaled Kubernetes pods, etc.) — startup latency and peak memory directly drive cost and SLA:
 - Shorter cold-start on every new container (one pass instead of load + cast).

--- a/gliner/model.py
+++ b/gliner/model.py
@@ -304,18 +304,22 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
 
         Args:
             dtype: Quantization type. Options:
-                - ``"fp16"`` (default): float16 half-precision. On GPU, uses Tensor Core
-                  acceleration for ~1.4x speedup. On CPU, applies dynamic quantization
-                  (reduces memory, no speed benefit).
-                - ``"bf16"``: bfloat16 half-precision. Better numerical stability than
-                  fp16 with slightly less speedup (~1.2x).
-                - ``"int8"``: int8 quantization (GPU and CPU). On CPU, uses PyTorch's
-                  built-in dynamic quantization with FBGEMM int8 kernels (~1.6x
-                  speedup). On GPU, uses ``torchao`` int8 weight-only quantization
+                - ``"int8"`` (recommended): int8 quantization (GPU and CPU). On CPU,
+                  uses PyTorch's built-in dynamic quantization with FBGEMM int8 kernels
+                  (~1.6x speedup). On GPU, uses ``torchao`` int8 weight-only quantization
                   (~50% memory reduction, no speed gain; requires the ``torchao``
                   package). Stock DeBERTa-based models lose accuracy with int8;
                   use this with models that have been fine-tuned with
                   quantization-aware training (QAT).
+                - ``"fp16"`` (default): float16. **Deprecated on GPU** — it's a pure
+                  downcast equivalent to ``model.to(torch.float16)``; prefer
+                  ``dtype="fp16"`` on ``GLiNER.from_pretrained`` or
+                  ``model.to(torch.float16)`` post-load. On CPU this is the only
+                  non-deprecated path and applies real dynamic quantization to
+                  ``nn.Linear`` layers (reduces memory, no speed benefit).
+                - ``"bf16"``: bfloat16. **Deprecated on both devices** — it's a pure
+                  downcast; prefer ``dtype="bf16"`` on ``GLiNER.from_pretrained`` or
+                  ``model.to(torch.bfloat16)`` post-load.
 
         Raises:
             RuntimeError: If the model is an ONNX model (use ONNX quantization instead).
@@ -324,9 +328,9 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
 
         Examples:
             >>> model = GLiNER.from_pretrained("urchade/gliner_small-v2.1", map_location="cuda")
-            >>> model.quantize()           # fp16 half-precision on GPU — ~1.4x faster
-            >>> model.quantize("bf16")     # bfloat16 on GPU — ~1.2x faster
             >>> model.quantize("int8")     # int8 quantization (torchao on GPU, FBGEMM on CPU)
+            >>> # For precision-only changes, prefer:
+            >>> model = GLiNER.from_pretrained("urchade/gliner_small-v2.1", dtype="bf16")
         """
         if self.onnx_model:
             raise RuntimeError(
@@ -345,6 +349,22 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
         if torch_dtype == "int8":
             self._apply_int8_quantization()
             return
+
+        # Pure-downcast paths (bf16 on any device, fp16 on GPU) are equivalent to
+        # ``model.to(torch_dtype)``. Steer users at the cheaper ``dtype=`` load path.
+        # CPU fp16 is real dynamic quantization of ``nn.Linear`` and stays as-is.
+        is_pure_downcast = (self.device.type == "cuda") or (torch_dtype == torch.bfloat16)
+        if is_pure_downcast:
+            warnings.warn(
+                f"`quantize({dtype!r})` on {self.device.type} is a pure downcast to "
+                f"{torch_dtype}, not real quantization. This overload is deprecated and "
+                f"will be removed in a future release; use `model.to({torch_dtype})` "
+                f"post-load, or pass `dtype={dtype!r}` to `GLiNER.from_pretrained(...)` "
+                f"for a cheaper load. `quantize('int8')` remains the recommended path "
+                f"for real quantization.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         if self.device.type == "cuda":
             if torch_dtype == torch.bfloat16:

--- a/gliner/model.py
+++ b/gliner/model.py
@@ -265,6 +265,30 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
         "int8": "int8",
     }
 
+    _DTYPE_MAP = {
+        "fp16": torch.float16,
+        "float16": torch.float16,
+        "half": torch.float16,
+        "bf16": torch.bfloat16,
+        "bfloat16": torch.bfloat16,
+        "fp32": torch.float32,
+        "float32": torch.float32,
+        "float": torch.float32,
+    }
+
+    @classmethod
+    def _parse_dtype(cls, dtype) -> Optional[torch.dtype]:
+        if dtype is None:
+            return None
+        if isinstance(dtype, torch.dtype):
+            return dtype
+        if isinstance(dtype, str):
+            key = dtype.lower()
+            if key not in cls._DTYPE_MAP:
+                raise ValueError(f"Unknown dtype {dtype!r}. Supported: {sorted(cls._DTYPE_MAP.keys())}")
+            return cls._DTYPE_MAP[key]
+        raise TypeError(f"dtype must be str or torch.dtype, got {type(dtype).__name__}")
+
     def quantize(self, dtype: str = "fp16") -> None:
         """Apply quantization to the model.
 
@@ -506,13 +530,21 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
         return cls._set_tokenizer_spec_tokens(tokenizer)
 
     @classmethod
-    def _load_state_dict(cls, model_file: Path, map_location: str = "cpu"):
+    def _load_state_dict(
+        cls,
+        model_file: Path,
+        map_location: str = "cpu",
+        dtype: Optional[torch.dtype] = None,
+    ):
         """
         Load state dict from file.
 
         Args:
             model_file: Path to model file
             map_location: Device to map tensors to
+            dtype: If set, floating-point tensors are cast to this dtype during
+                loading so the state dict never fully materializes at the
+                on-disk precision.
 
         Returns:
             State dict
@@ -521,9 +553,16 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
             state_dict = {}
             with safe_open(model_file, framework="pt", device=map_location) as f:
                 for key in f.keys():
-                    state_dict[key] = f.get_tensor(key)
+                    tensor = f.get_tensor(key)
+                    if dtype is not None and tensor.is_floating_point() and tensor.dtype != dtype:
+                        tensor = tensor.to(dtype)
+                    state_dict[key] = tensor
         else:
             state_dict = torch.load(model_file, map_location=torch.device(map_location), weights_only=True)
+            if dtype is not None:
+                for k, v in state_dict.items():
+                    if torch.is_tensor(v) and v.is_floating_point() and v.dtype != dtype:
+                        state_dict[k] = v.to(dtype)
         return state_dict
 
     @classmethod
@@ -717,6 +756,7 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
         resize_token_embeddings: Optional[bool] = True,
         compile_torch_model: Optional[bool] = False,
         quantize: Union[bool, str] = False,
+        dtype: Optional[Union[str, torch.dtype]] = None,
         load_onnx_model: Optional[bool] = False,
         onnx_model_file: Optional[str] = "model.onnx",
         session_options=None,
@@ -747,6 +787,12 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
             quantize: Quantization dtype. ``True`` or ``"fp16"`` for float16,
                 ``"bf16"`` for bfloat16, ``"int8"`` for int8 dynamic quantization
                 (requires ``torchao``). ``False`` to disable.
+            dtype: Target floating-point dtype for the loaded weights (e.g.
+                ``torch.bfloat16``, ``"bf16"``, ``"fp16"``). When set, the model
+                shell is pre-cast and each state-dict tensor is cast during
+                reading, so the full fp32 copy is never materialized — peak
+                host memory is roughly half of the default path for bf16/fp16.
+                Prefer this over ``quantize`` for plain precision changes.
             load_onnx_model: Whether to load ONNX model instead of PyTorch.
             onnx_model_file: Path to ONNX model file.
             session_options: ONNX runtime session options.
@@ -802,9 +848,17 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
 
             cls._resize_token_embeddings(instance, config, tokenizer, resize_token_embeddings)
 
-            # Load state dict
-            state_dict = cls._load_state_dict(model_file, map_location)
+            torch_dtype = cls._parse_dtype(dtype)
+            if torch_dtype is not None:
+                # Pre-cast the random-init shell so the model never exists at
+                # fp32 alongside the loaded state dict. ``.to(floating_dtype)``
+                # only touches floating-point params/buffers.
+                instance.model.to(torch_dtype)
+
+            # Load state dict (tensors cast to ``torch_dtype`` during read when set)
+            state_dict = cls._load_state_dict(model_file, map_location, dtype=torch_dtype)
             instance.model.load_state_dict(state_dict, strict=strict)
+            del state_dict
             instance.model.to(map_location)
 
             if compile_torch_model:
@@ -815,8 +869,8 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
                     warnings.warn("Cannot compile model on CPU. Set `map_location='cuda'` to compile.", stacklevel=2)
 
             if quantize:
-                dtype = quantize if isinstance(quantize, str) else "fp16"
-                instance.quantize(dtype)
+                quantize_dtype = quantize if isinstance(quantize, str) else "fp16"
+                instance.quantize(quantize_dtype)
 
             instance.eval()
         else:
@@ -4117,6 +4171,7 @@ class GLiNER(nn.Module, PyTorchModelHubMixin):
         resize_token_embeddings: Optional[bool] = True,
         compile_torch_model: Optional[bool] = False,
         quantize: Union[bool, str] = False,
+        dtype: Optional[Union[str, torch.dtype]] = None,
         load_onnx_model: Optional[bool] = False,
         onnx_model_file: Optional[str] = "model.onnx",
         # Config overrides
@@ -4148,6 +4203,11 @@ class GLiNER(nn.Module, PyTorchModelHubMixin):
             quantize: Quantization dtype. ``True`` or ``"fp16"`` for float16,
                 ``"bf16"`` for bfloat16, ``"int8"`` for int8 dynamic quantization
                 (requires ``torchao``). ``False`` to disable.
+            dtype: Target floating-point dtype for the loaded weights (e.g.
+                ``torch.bfloat16``, ``"bf16"``, ``"fp16"``). When set, weights
+                are cast during the state-dict read so the fp32 copy is never
+                fully materialized; prefer this over ``quantize`` for plain
+                precision changes.
             load_onnx_model: Whether to load ONNX model instead of PyTorch.
             onnx_model_file: Path to ONNX model file.
             max_length: Override max_length in config.
@@ -4163,6 +4223,7 @@ class GLiNER(nn.Module, PyTorchModelHubMixin):
             >>> model = GLiNER.from_pretrained("urchade/gliner_small-v2.1")
             >>> model = GLiNER.from_pretrained("knowledgator/gliner-bi-small-v1.0")
             >>> model = GLiNER.from_pretrained("path/to/local/model", quantize=True)
+            >>> model = GLiNER.from_pretrained("urchade/gliner_small-v2.1", dtype="bf16")
         """
         model_dir = Path(model_id)
         if not model_dir.exists():
@@ -4212,6 +4273,7 @@ class GLiNER(nn.Module, PyTorchModelHubMixin):
             resize_token_embeddings=resize_token_embeddings,
             compile_torch_model=compile_torch_model,
             quantize=quantize,
+            dtype=dtype,
             max_length=max_length,
             max_width=max_width,
             post_fusion_schema=post_fusion_schema,

--- a/gliner/model.py
+++ b/gliner/model.py
@@ -281,13 +281,23 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
         if dtype is None:
             return None
         if isinstance(dtype, torch.dtype):
-            return dtype
-        if isinstance(dtype, str):
+            resolved = dtype
+        elif isinstance(dtype, str):
             key = dtype.lower()
             if key not in cls._DTYPE_MAP:
                 raise ValueError(f"Unknown dtype {dtype!r}. Supported: {sorted(cls._DTYPE_MAP.keys())}")
-            return cls._DTYPE_MAP[key]
-        raise TypeError(f"dtype must be str or torch.dtype, got {type(dtype).__name__}")
+            resolved = cls._DTYPE_MAP[key]
+        else:
+            raise TypeError(f"dtype must be str or torch.dtype, got {type(dtype).__name__}")
+        # ``instance.model.to(dtype)`` only accepts floating-point/complex dtypes;
+        # reject e.g. torch.int8 / torch.bool up front with a clearer error than
+        # the one PyTorch raises deep in the load path.
+        if not resolved.is_floating_point:
+            raise ValueError(
+                f"dtype must be a floating-point dtype (e.g. torch.bfloat16, torch.float16, "
+                f"torch.float32), got {resolved}. For int8 quantization use `quantize='int8'`."
+            )
+        return resolved
 
     def quantize(self, dtype: str = "fp16") -> None:
         """Apply quantization to the model.
@@ -870,6 +880,19 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
 
             if quantize:
                 quantize_dtype = quantize if isinstance(quantize, str) else "fp16"
+                if torch_dtype is not None and quantize_dtype.lower() in {
+                    "fp16", "float16", "half", "bf16", "bfloat16",
+                }:
+                    # ``quantize`` in these cases is just a downcast and will
+                    # overwrite the precision chosen via ``dtype``. Warn rather
+                    # than silently resolve one way.
+                    warnings.warn(
+                        f"Both `dtype={dtype!r}` and `quantize={quantize!r}` were passed; "
+                        f"`quantize` will override the loaded precision by casting to "
+                        f"{quantize_dtype!r}. Pass only `dtype=` for plain precision changes, "
+                        f"or only `quantize='int8'` for real quantization.",
+                        stacklevel=2,
+                    )
                 instance.quantize(quantize_dtype)
 
             instance.eval()


### PR DESCRIPTION
**Stacked on [#348](https://github.com/urchade/GLiNER/pull/348).** Until that merges, this PR contains two commits — the `dtype` addition from #348 and the deprecation commit from this PR. Review only the top commit (`ac6adb1`) here; the diff against #348's branch is isolated to that change.

## Motivation

After #348, pure precision changes (fp16/bf16) have a dedicated, memory-efficient path via `GLiNER.from_pretrained(dtype=...)`. The `quantize(...)` surface ended up doing two different things under one name:

| `quantize=` | Device | What happens | Real quant? |
|---|---|---|---|
| `True` / `"fp16"` | GPU | `model.half()` | **No — pure downcast** |
| `True` / `"fp16"` | CPU | `quantize_dynamic(Linear, fp16)` | Yes — dynamic quant |
| `"bf16"` | GPU | `model.bfloat16()` | **No — pure downcast** |
| `"bf16"` | CPU | `model.bfloat16()` | **No — pure downcast** |
| `"int8"` | GPU | torchao int8 weight-only | Yes |
| `"int8"` | CPU | `quantize_dynamic(Linear, qint8)` (FBGEMM) | Yes |

Three of those six rows are just `.to(dtype)` with an extra fp32 intermediate. This PR steers users away from those rows and toward `dtype=` / `model.to(dtype)` — without removing them.

## What changes

- `model.quantize("fp16"/True)` on **GPU** → `DeprecationWarning` (pure downcast; use `model.to(torch.float16)` or `dtype="fp16"` on `from_pretrained`).
- `model.quantize("bf16")` on **any device** → `DeprecationWarning` (pure downcast; use `model.to(torch.bfloat16)` or `dtype="bf16"`).
- `model.quantize("fp16")` on **CPU** → **unchanged, no warning** (this is real dynamic quantization of `nn.Linear`, not a downcast).
- `model.quantize("int8")` → **unchanged, no warning**.
- The existing `from_pretrained(dtype=..., quantize=...)` conflict warning introduced in #348 still fires when both are set (it covers the "silently overrides my `dtype`" footgun).
- Behavior is preserved everywhere. Removal of the deprecated paths is a future PR once users have had time to migrate.

## Docs

`docs/usage.md` rewritten:
- "Quantization, Compilation & FlashDeBERTa" now shows `dtype="fp16"` as the recommended path for GPU half-precision inference.
- Added a "`quantize=` vs `dtype=`" section explaining the taxonomy, including the CPU-fp16 exception.
- Benchmark table updated to use `dtype="fp16"` naming.
- `model.quantize(...)` docstring rewritten to mark deprecated paths and recommend `model.to(...)` / `dtype=` alternatives.

## Release coordination

`gliner 0.2.26` (current PyPI) pre-dates PR #342 which introduced the `quantize=` surface, so no released wheel uses these paths. The deprecation mainly protects users installing from `main` / git. Removal in a later PR is low-risk.

## Test plan
- [x] Unit sanity: `model.quantize("fp16")` / `"bf16"` on `cuda` → one `DeprecationWarning`.
- [x] Unit sanity: `model.quantize("bf16")` on `cpu` → one `DeprecationWarning`.
- [x] Unit sanity: `model.quantize("fp16")` on `cpu` → no `DeprecationWarning` from our code (only the pre-existing CPU-speed UserWarning).
- [x] Ruff clean on modified regions.
- [ ] Manual end-to-end smoke: load a real hub checkpoint, call `model.quantize("bf16")`, confirm warning surfaces and model still runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)