### PR TITLE
Implement a proper gliner client, fix bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ data.json
 logs/
 models/
 
+labels_trie.cpp
+
 # Distribution / packaging
 .Python
 build/

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -46,10 +46,10 @@ from `asyncio`.
 ```python
 from gliner.serve import GLiNERClient
 
-client = GLiNERClient()
+client = GLiNERClient()  # defaults to http://localhost:8000/gliner
 result = client.predict(
     "John works at Google in Mountain View",
-    labels=["person", "organization", "location"]
+    labels=["person", "organization", "location"],
 )
 print(result)
 # {'entities': [
@@ -59,7 +59,35 @@ print(result)
 # ]}
 ```
 
-**HTTP request:**
+`GLiNERClient` is a pure HTTP client built on the Python standard library —
+it does **not** import `ray` and does **not** join the Ray cluster, so it
+runs from any Python process (including environments where `ray` is not
+installed). Construct it with a custom URL/prefix or timeout as needed:
+
+```python
+client = GLiNERClient(
+    base_url="http://gliner.internal:8000",
+    route_prefix="/gliner",
+    timeout=30.0,
+    max_concurrency=32,   # bound on concurrent in-flight HTTP requests
+)
+```
+
+Passing a list of texts preserves server-side dynamic batching — each text
+is dispatched as its own HTTP request concurrently (threads for `predict`,
+`asyncio.gather` for `predict_async`) so Ray Serve's `@serve.batch`
+coalesces them into a single forward pass:
+
+```python
+outputs = client.predict(
+    ["John works at Google", "Paris is in France"],
+    labels=["person", "organization", "location"],
+)  # → list[dict], one per input text
+```
+
+Network or server errors surface as `gliner.serve.client.GLiNERClientError`.
+
+**HTTP request (no client library):**
 ```bash
 curl -X POST http://localhost:8000/gliner \
   -H "Content-Type: application/json" \
@@ -128,16 +156,100 @@ result = ref.result()
 
 ## Relation Extraction
 
-For models that support relation extraction:
+GLiNER-RelEx models (e.g. `knowledgator/gliner-relex-large-v0.5`,
+`knowledgator/gliner-token-relex-v1.0`) jointly extract entities and the
+relations between them in a single forward pass. The server auto-detects
+relation support by inspecting `model.config.model_type` and enables the
+relex code path when it contains `"relex"` — no extra flag is needed.
+
+### Start a RelEx server
+
+```bash
+python -m gliner.serve \
+    --model knowledgator/gliner-relex-large-v1.0 \
+    --dtype bfloat16 \
+    --max-batch-size 16
+```
+
+### Predict via the client
 
 ```python
+from gliner.serve import GLiNERClient
+
+client = GLiNERClient()  # http://localhost:8000/gliner
+
+text = "Bill Gates founded Microsoft in 1975. The company is headquartered in Redmond."
+
 result = client.predict(
-    "John works at Google",
-    labels=["person", "organization"],
-    relations=["works_at", "founded_by"]
+    text,
+    labels=["person", "organization", "date", "location"],
+    relations=["founded", "founded_in", "headquartered_in"],
+    threshold=0.5,
+    relation_threshold=0.5,
 )
-# {'entities': [...], 'relations': [...]}
+
+for ent in result["entities"]:
+    print(f"  {ent['text']} ({ent['label']})")
+
+for rel in result["relations"]:
+    head = result["entities"][rel["head"]["entity_idx"]]
+    tail = result["entities"][rel["tail"]["entity_idx"]]
+    print(f"  {head['text']} --[{rel['relation']}]--> {tail['text']}")
 ```
+
+For a batched call, pass a list of texts — each one dispatches as its own
+request so the server can coalesce them into a single relex forward pass:
+
+```python
+results = client.predict(
+    [
+        "Bill Gates founded Microsoft in 1975.",
+        "Apple is headquartered in Cupertino.",
+    ],
+    labels=["person", "organization", "location", "date"],
+    relations=["founded", "founded_in", "headquartered_in"],
+)
+# results == [ {"entities": [...], "relations": [...]}, {...} ]
+```
+
+### In-process (GLiNERFactory)
+
+```python
+from gliner.serve import GLiNERFactory
+
+with GLiNERFactory(model="knowledgator/gliner-relex-large-v0.5") as llm:
+    out = llm.predict(
+        "Bill Gates founded Microsoft in 1975.",
+        labels=["person", "organization", "date"],
+        relations=["founded", "founded_in"],
+    )
+```
+
+### HTTP (curl)
+
+```bash
+curl -X POST http://localhost:8000/gliner \
+  -H "Content-Type: application/json" \
+  -d '{
+        "text": "Bill Gates founded Microsoft in 1975.",
+        "labels": ["person", "organization", "date"],
+        "relations": ["founded", "founded_in"],
+        "threshold": 0.5,
+        "relation_threshold": 0.5
+      }'
+```
+
+**Response shape for RelEx models:**
+```python
+{
+    "entities":  [{"start", "end", "text", "label", "score"}, ...],
+    "relations": [{"relation", "score",
+                   "head": {"entity_idx": int, ...},
+                   "tail": {"entity_idx": int, ...}}, ...],
+}
+```
+For NER-only models the `"relations"` key is omitted; passing `relations=`
+to such a model is a no-op.
 
 ## All CLI Options
 
@@ -152,7 +264,7 @@ Model Configuration:
 
 Batching:
   --max-batch-size      Max batch size (default: 32)
-  --batch-wait-timeout-ms  Batch wait timeout (default: 50)
+  --batch-wait-timeout-ms  Batch wait timeout (default: 10)
   --precompiled-batch-sizes  Comma-separated sizes (default: 1,2,4,8,16,32)
 
 Replicas:
@@ -165,7 +277,8 @@ Performance:
   --no-compile             Disable torch.compile
 
 Memory:
-  --target-memory-fraction  GPU memory fraction (default: 0.8)
+  --target-memory-fraction  GPU memory fraction (default: 0.9)
+  --memory-overhead-factor  Safety margin on memory estimates (default: 1.3)
 
 Server:
   --route-prefix        HTTP route (default: /gliner)

--- a/gliner/modeling/base.py
+++ b/gliner/modeling/base.py
@@ -2186,17 +2186,8 @@ class UniEncoderSpanRelexModel(UniEncoderSpanModel):
                 - target_mask: Packed mask of shape (B, M).
         """
         B, N, D = representations.shape
-
-        # ``lengths.max().item()`` would force a GPU→CPU sync to compress the output
-        # from ``N`` to ``max_len``. Under ``torch.compile`` with ``capture_scalar_outputs``
-        # the sync is traced symbolically and we keep the packing benefit; in eager
-        # execution we skip packing (use the full ``N``) to stay sync-free, at the cost
-        # of some downstream compute that masked positions would have saved.
-        if torch.compiler.is_compiling():
-            lengths = rep_mask.sum(dim=-1)
-            max_len = lengths.max().item()
-        else:
-            max_len = N
+        lengths = rep_mask.sum(dim=-1)
+        max_len = lengths.max().item()
 
         if max_len != N:
             target_rep = representations.new_zeros(B, max_len, D)

--- a/gliner/serve/client.py
+++ b/gliner/serve/client.py
@@ -1,43 +1,107 @@
-"""Client for accessing GLiNER Ray Serve deployment from Python."""
+"""HTTP client for the GLiNER Ray Serve deployment.
 
+This is a thin wrapper around the server's HTTP endpoint — it does not import
+Ray and does not join the Ray cluster, so it works from any Python process
+with only the standard library available.
+
+To preserve server-side dynamic batching when multiple texts are submitted,
+the client dispatches each text as its own HTTP request concurrently so Ray
+Serve's ``@serve.batch`` can coalesce them into a single forward pass. A
+sequential loop of calls would serialize on the wire and defeat batching.
+"""
+
+import json
 from typing import Any, Dict, List, Optional, Union
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+from concurrent.futures import ThreadPoolExecutor
+
+DEFAULT_BASE_URL = "http://localhost:8000"
+DEFAULT_ROUTE_PREFIX = "/gliner"
+
+
+class GLiNERClientError(RuntimeError):
+    """Raised when the GLiNER server returns an error or is unreachable."""
 
 
 class GLiNERClient:
-    """Client for accessing a running GLiNER Ray Serve deployment.
-
-    This client can be used from any Python process (same machine or remote)
-    to make predictions against a running GLiNER server.
+    """HTTP client for a running GLiNER Ray Serve deployment.
 
     Example:
         >>> from gliner.serve import GLiNERClient
         >>> client = GLiNERClient()
-        >>> results = client.predict(
+        >>> client.predict(
         ...     "John works at Google in Mountain View",
-        ...     labels=["person", "organization", "location"]
+        ...     labels=["person", "organization", "location"],
         ... )
-        >>> print(results)
-        {'entities': [{'start': 0, 'end': 4, 'text': 'John', 'label': 'person', 'score': 0.95}, ...]}
+        {'entities': [{'start': 0, 'end': 4, 'text': 'John', 'label': 'person', ...}, ...]}
     """
 
     def __init__(
         self,
-        deployment_name: str = "gliner",
-        ray_address: Optional[str] = None,
+        base_url: str = DEFAULT_BASE_URL,
+        route_prefix: str = DEFAULT_ROUTE_PREFIX,
+        timeout: float = 30.0,
+        max_concurrency: int = 32,
     ):
-        """Initialize client connection to GLiNER deployment.
+        """Initialize the HTTP client.
 
         Args:
-            deployment_name: Name of the Ray Serve deployment.
-            ray_address: Ray cluster address. If None, connects to local cluster.
+            base_url: Scheme + host + port of the Ray Serve HTTP proxy.
+            route_prefix: Route prefix the deployment is mounted under (must
+                match ``GLiNERServeConfig.route_prefix``).
+            timeout: Per-request timeout in seconds.
+            max_concurrency: Maximum in-flight HTTP requests when predicting
+                on a list of texts. Bounds the client-side thread pool.
         """
-        import ray
-        from ray import serve
+        self.url = base_url.rstrip("/") + "/" + route_prefix.strip("/")
+        self.timeout = timeout
+        self.max_concurrency = max_concurrency
 
-        if not ray.is_initialized():
-            ray.init(address=ray_address, ignore_reinit_error=True)
+    def _post(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        data = json.dumps(payload).encode("utf-8")
+        req = Request(
+            self.url,
+            data=data,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with urlopen(req, timeout=self.timeout) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except HTTPError as e:
+            body = e.read().decode("utf-8", errors="replace")
+            raise GLiNERClientError(
+                f"GLiNER server returned HTTP {e.code}: {body}"
+            ) from e
+        except URLError as e:
+            raise GLiNERClientError(
+                f"Could not reach GLiNER server at {self.url}: {e.reason}"
+            ) from e
 
-        self._handle = serve.get_deployment_handle(deployment_name, "gliner")
+    @staticmethod
+    def _build_payload(
+        text: str,
+        labels: List[str],
+        relations: Optional[List[str]],
+        threshold: Optional[float],
+        relation_threshold: Optional[float],
+        flat_ner: bool,
+        multi_label: bool,
+    ) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "text": text,
+            "labels": labels,
+            "flat_ner": flat_ner,
+            "multi_label": multi_label,
+        }
+        if relations is not None:
+            payload["relations"] = relations
+        if threshold is not None:
+            payload["threshold"] = threshold
+        if relation_threshold is not None:
+            payload["relation_threshold"] = relation_threshold
+        return payload
 
     def predict(
         self,
@@ -49,35 +113,26 @@ class GLiNERClient:
         flat_ner: bool = True,
         multi_label: bool = False,
     ) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
-        """Make predictions using the GLiNER server.
+        """Blocking prediction. ``str`` in → ``dict`` out; ``list`` in → ``list`` out."""
+        single = isinstance(text, str)
+        items = [text] if single else list(text)
 
-        Args:
-            text: Input text or list of texts.
-            labels: Entity type labels to extract.
-            relations: Relation type labels (for relex models).
-            threshold: Confidence threshold for entities.
-            relation_threshold: Confidence threshold for relations.
-            flat_ner: Whether to use flat NER.
-            multi_label: Whether to allow multiple labels per span.
-
-        Returns:
-            Single result dict or list of result dicts containing:
-                - "entities": List of entity dicts
-                - "relations": List of relation dicts (if model supports)
-        """
-        if isinstance(text, list):
-            refs = [
-                self._handle.predict.remote(
-                    t, labels, relations, threshold, relation_threshold, flat_ner, multi_label
-                )
-                for t in text
-            ]
-            return [ref.result() for ref in refs]
-        else:
-            ref = self._handle.predict.remote(
-                text, labels, relations, threshold, relation_threshold, flat_ner, multi_label
+        payloads = [
+            self._build_payload(
+                t, labels, relations, threshold, relation_threshold,
+                flat_ner, multi_label,
             )
-            return ref.result()
+            for t in items
+        ]
+
+        if len(payloads) == 1:
+            results = [self._post(payloads[0])]
+        else:
+            workers = min(self.max_concurrency, len(payloads))
+            with ThreadPoolExecutor(max_workers=workers) as pool:
+                results = list(pool.map(self._post, payloads))
+
+        return results[0] if single else results
 
     async def predict_async(
         self,
@@ -89,35 +144,37 @@ class GLiNERClient:
         flat_ner: bool = True,
         multi_label: bool = False,
     ) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
-        """Async version of predict."""
-        if isinstance(text, list):
-            import asyncio
+        """Async prediction. Concurrent calls coalesce into one server-side batch."""
+        import asyncio
 
-            refs = [
-                self._handle.predict.remote(
-                    t, labels, relations, threshold, relation_threshold, flat_ner, multi_label
-                )
-                for t in text
-            ]
-            results = await asyncio.gather(*[ref for ref in refs])
-            return list(results)
-        else:
-            return await self._handle.predict.remote(
-                text, labels, relations, threshold, relation_threshold, flat_ner, multi_label
+        single = isinstance(text, str)
+        items = [text] if single else list(text)
+
+        payloads = [
+            self._build_payload(
+                t, labels, relations, threshold, relation_threshold,
+                flat_ner, multi_label,
             )
+            for t in items
+        ]
+
+        results = await asyncio.gather(
+            *(asyncio.to_thread(self._post, p) for p in payloads)
+        )
+
+        return results[0] if single else list(results)
 
 
 def get_client(
-    deployment_name: str = "gliner",
-    ray_address: Optional[str] = None,
+    base_url: str = DEFAULT_BASE_URL,
+    route_prefix: str = DEFAULT_ROUTE_PREFIX,
+    timeout: float = 30.0,
+    max_concurrency: int = 32,
 ) -> GLiNERClient:
-    """Get a client for the GLiNER Ray Serve deployment.
-
-    Args:
-        deployment_name: Name of the Ray Serve deployment.
-        ray_address: Ray cluster address. If None, connects to local cluster.
-
-    Returns:
-        GLiNERClient instance for making predictions.
-    """
-    return GLiNERClient(deployment_name, ray_address)
+    """Convenience constructor for :class:`GLiNERClient`."""
+    return GLiNERClient(
+        base_url=base_url,
+        route_prefix=route_prefix,
+        timeout=timeout,
+        max_concurrency=max_concurrency,
+    )

--- a/gliner/serve/server.py
+++ b/gliner/serve/server.py
@@ -711,11 +711,20 @@ class GLiNERFactory:
         return results[0] if single else results
 
     def shutdown(self) -> None:
-        """Tear down the Ray Serve deployment. Idempotent."""
+        """Tear down the Ray Serve deployment and the Ray runtime it booted.
+
+        Idempotent. Shutting down Ray after Serve avoids leaving the driver
+        attached to a detached Serve instance — the latter produces noisy
+        ``ServeController ... killed by ray.kill`` retry warnings in the
+        raylet log when the process exits.
+        """
         if self._closed:
             return
+        import ray
         from ray import serve as ray_serve
         ray_serve.shutdown()
+        if ray.is_initialized():
+            ray.shutdown()
         self._closed = True
 
     def __enter__(self):


### PR DESCRIPTION
## Summary

Rewrites `GLiNERClient` as a pure HTTP client, drops the Ray dependency from the client path, fixes a `torch.compile`-related packing bug in the span-relex model, cleans up `GLiNERFactory.shutdown()`, and substantially expands the serving docs (RelEx section + client usage).

## Details

### `gliner/serve/client.py` — HTTP-only client

- Replaces the `ray` / `serve.get_deployment_handle` based client with a stdlib-only HTTP wrapper built on `urllib.request`.
- New `GLiNERClientError` exception type surfaces HTTP and network failures.
- New constructor signature: `GLiNERClient(base_url, route_prefix, timeout, max_concurrency)` — no longer needs a Ray cluster or deployment handle.
- `predict(...)` and `predict_async(...)`:
  - `str` in → `dict` out; `list` in → `list` out (preserved).
  - Batch calls fan out **one HTTP request per text** concurrently (threads for sync, `asyncio.to_thread` + `asyncio.gather` for async) so the server-side `@serve.batch` coalesces them into a single forward pass. A sequential loop would serialize on the wire and defeat batching.
  - `max_concurrency` bounds the in-flight request count.
- `_build_payload(...)` centralizes request shape; optional fields (`relations`, `threshold`, `relation_threshold`) are only included when set.
- `get_client(...)` updated to mirror the new constructor.

### `gliner/modeling/base.py` — simpler packing in `UniEncoderSpanRelexModel._pack`

- Drops the `torch.compiler.is_compiling()` branch that previously avoided a GPU→CPU sync in eager mode at the cost of skipping packing.
- Always computes `lengths = rep_mask.sum(dim=-1)` and `max_len = lengths.max().item()`, so eager execution now benefits from packing too.

### `gliner/serve/server.py` — cleaner shutdown

- `GLiNERFactory.shutdown()` now calls `ray.shutdown()` after `serve.shutdown()` when Ray is initialized.
- Prevents noisy `ServeController ... killed by ray.kill` retry warnings in the raylet log on process exit. Still idempotent.

### `docs/serving.md`

- Expands the `GLiNERClient` section: clarifies it’s a pure HTTP client (no Ray import), documents the custom constructor args, and explains the batching semantics with an example.
- Adds a full **Relation Extraction** section covering RelEx server startup (`--model knowledgator/gliner-relex-large-v1.0`), client usage (sync + batched), in-process `GLiNERFactory` usage, a `curl` example, and the response shape.
- Documents new/changed CLI defaults: `--batch-wait-timeout-ms` 50 → 10, `--target-memory-fraction` 0.8 → 0.9, plus `--memory-overhead-factor 1.3`.

### `.gitignore`

- Adds `labels_trie.cpp` (generated artifact) to the ignore list.

## Notable behavior changes

- **Client no longer needs Ray.** Any previous code constructing `GLiNERClient(deployment_name=..., ray_address=...)` must migrate to `GLiNERClient(base_url=..., route_prefix=...)`.
- **Eager mode packs length-variable inputs** in `UniEncoderSpanRelexModel`, incurring a GPU→CPU sync but reducing downstream compute on masked positions.
- **`GLiNERFactory` context manager exit** now fully tears down Ray, not just Serve.
