### PR TITLE
Add variant= to from_pretrained for selective half-precision downloads

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -402,12 +402,13 @@ model = GLiNER.from_pretrained("org/gliner_bf16-v1", variant="bf16")
 # for gliner_medium-v2.1) when a bf16 file is published.
 ```
 
-Behavior:
-- `variant=None` (default): unchanged — pulls the whole repo and loads `model.safetensors`.
-- `variant="fp16"` / `"bf16"`: `snapshot_download` is filtered with `allow_patterns` so only `model.{variant}.safetensors` (plus configs and tokenizer assets) is fetched. `dtype=` is inferred from `variant` if not set; passing both with mismatched precisions raises.
-- If the variant file isn't published in the repo, you get a `FileNotFoundError` pointing you at `dtype=` for the in-memory cast path. There's no silent fallback — falling back to fp32 would defeat the download savings.
+Behavior — `variant=` is a *best-effort hint*, not a hard requirement:
 
-This is the lever to pull for cold-start cost when bytes-on-the-wire dominate; combine with `dtype=` (which is now redundant when `variant=` is set, but harmless if it matches) for the lowest peak memory after download.
+- `variant=None` (default): unchanged — pulls the whole repo and loads `model.safetensors`.
+- `variant="fp16"` / `"bf16"` and the variant **is** published: `snapshot_download` is filtered with `allow_patterns` so only `model.{variant}.safetensors` (plus configs and tokenizer assets) is fetched. `dtype=` is inferred from `variant`; passing both with mismatched precisions raises.
+- `variant="fp16"` / `"bf16"` and the variant **is not** published: a `UserWarning` is emitted and the loader falls back to the default fp32 file plus an in-memory cast — same outcome as passing `dtype=` alone, no error, no I/O win. The warning text tells the user the publisher hasn't uploaded the file so the bandwidth savings didn't apply.
+
+This is the lever to pull for cold-start cost when bytes-on-the-wire dominate. Set `variant="bf16"` and forget about it — if the publisher has the variant file you get the I/O savings, and if they don't you get the in-memory `dtype=` behavior with a one-line warning. The probe uses `huggingface_hub.HfApi().list_repo_files` (one cheap API call) before downloading.
 
 ### Quantization, Compilation & FlashDeBERTa
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -392,6 +392,23 @@ Accepted values: `"fp16"` / `"float16"` / `"half"`, `"bf16"` / `"bfloat16"`, `"f
 
 `dtype` covers plain precision changes (bf16/fp16/fp32). For int8 / torchao / CPU dynamic quantization, keep using `quantize` (see below). The two can be combined if desired.
 
+#### Selective download (`variant`)
+
+`dtype=` casts in memory but the on-disk file is still fp32, so the bytes pulled from the Hub don't shrink. If a publisher uploads a half-precision variant of the file (`model.fp16.safetensors` or `model.bf16.safetensors`, following the transformers naming convention), pass `variant=` to download *only* that file:
+
+```python
+model = GLiNER.from_pretrained("org/gliner_bf16-v1", variant="bf16")
+# Halves bytes-on-the-wire vs. the default fp32 download (~745 MB -> ~370 MB
+# for gliner_medium-v2.1) when a bf16 file is published.
+```
+
+Behavior:
+- `variant=None` (default): unchanged — pulls the whole repo and loads `model.safetensors`.
+- `variant="fp16"` / `"bf16"`: `snapshot_download` is filtered with `allow_patterns` so only `model.{variant}.safetensors` (plus configs and tokenizer assets) is fetched. `dtype=` is inferred from `variant` if not set; passing both with mismatched precisions raises.
+- If the variant file isn't published in the repo, you get a `FileNotFoundError` pointing you at `dtype=` for the in-memory cast path. There's no silent fallback — falling back to fp32 would defeat the download savings.
+
+This is the lever to pull for cold-start cost when bytes-on-the-wire dominate; combine with `dtype=` (which is now redundant when `variant=` is set, but harmless if it matches) for the lowest peak memory after download.
+
 ### Quantization, Compilation & FlashDeBERTa
 
 Combine `dtype="fp16"` (or `"bf16"`) with `compile_torch_model=True` for up to ~1.9x faster GPU inference with zero quality loss:

--- a/gliner/model.py
+++ b/gliner/model.py
@@ -15,9 +15,15 @@ from torch import nn
 from packaging import version
 from safetensors import safe_open
 from transformers import AutoTokenizer
-from huggingface_hub import HfApi, PyTorchModelHubMixin, snapshot_download
+from huggingface_hub import (
+    PyTorchModelHubMixin,
+    hf_hub_download,
+    snapshot_download,
+    try_to_load_from_cache,
+)
 from torch.utils.data import DataLoader
 from safetensors.torch import save_file
+from huggingface_hub.errors import EntryNotFoundError
 
 try:
     from onnxruntime.quantization import QuantType, quantize_dynamic
@@ -339,33 +345,58 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
     ) -> Optional[bool]:
         """Probe whether ``model.{variant}.safetensors`` is published.
 
-        For local paths the probe is a disk check. For Hub repos it calls
-        ``HfApi().list_repo_files``.
+        Resolution order (matches the ``transformers`` / ``huggingface_hub``
+        idiom — cheapest checks first, no list-files round-trip):
+
+        1. ``model_id`` is a local directory → ``Path.exists()``.
+        2. The file is in the local HF cache for this repo+revision →
+           ``try_to_load_from_cache``. Pure local lookup, no network.
+        3. ``local_files_only=True`` → return ``None`` (uncertain) without
+           hitting the network.
+        4. ``hf_hub_download`` for the variant filename: success means the
+           file exists (and is now cached, so the subsequent
+           ``snapshot_download`` reuses it); ``EntryNotFoundError`` means
+           the publisher hasn't uploaded a variant.
 
         Returns:
             ``True`` / ``False`` when known, or ``None`` when availability
-            cannot be determined (offline, transient API failure, gated
-            repo without auth). Callers should treat ``None`` as
-            "uncertain — try the narrow download and let it fail loudly".
+            cannot be determined (offline + uncached, transient API failure,
+            gated repo without auth). ``None`` is treated as "try the narrow
+            download and let it fail loudly".
         """
         target = f"model.{variant}.safetensors"
 
+        # 1. Local directory.
         model_dir = Path(model_id)
         if model_dir.exists() and model_dir.is_dir():
             return (model_dir / target).exists()
 
+        # 2. Already cached for this repo+revision? Pure local — no network.
+        # try_to_load_from_cache validates the repo_id format; an
+        # HFValidationError here means the input isn't a valid repo_id at
+        # all (e.g. a non-existent local path), so treat as uncertain.
+        try:
+            cached = try_to_load_from_cache(repo_id=model_id, filename=target, revision=revision)
+        except Exception:
+            return None
+        if isinstance(cached, str):
+            return True
+
+        # 3. Offline mode: can't probe further.
         if local_files_only:
             return None
 
+        # 4. Try-and-recover via hf_hub_download. Success caches the file so
+        # the subsequent snapshot_download reuses it (no double download).
         try:
-            files = HfApi().list_repo_files(repo_id=model_id, revision=revision, token=token)
+            hf_hub_download(repo_id=model_id, filename=target, revision=revision, token=token)
+            return True
+        except EntryNotFoundError:
+            return False
         except Exception:
-            # The list of possible huggingface_hub errors here is wide
-            # (network, auth, repo not found, gated). Treat any failure as
-            # "availability unknown" and let the subsequent download path
-            # produce the canonical error if there really is a problem.
+            # Auth / network / repo-not-found / gated — surface as uncertain
+            # and let the subsequent download path produce the canonical error.
             return None
-        return target in files
 
     @classmethod
     def _resolve_variant(
@@ -392,6 +423,15 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
             model_id, variant, revision=revision, token=token, local_files_only=local_files_only
         )
         if available is False:
+            # TODO(strict-variant): once half-precision variant files have been
+            # published for the flagship GLiNER models on the Hub, flip this
+            # branch to raise ``EntryNotFoundError`` (or a wrapped equivalent)
+            # instead of warning + falling back. That matches
+            # ``transformers.PreTrainedModel.from_pretrained(variant=...)``,
+            # which is strict — explicit > implicit. The soft-fallback was a
+            # transitional choice taken because, at PR-merge time, no GLiNER
+            # repo on the Hub shipped a variant file, so a strict surface
+            # would have been broken-on-arrival for every caller.
             warnings.warn(
                 f"variant={variant!r} requested but 'model.{variant}.safetensors' is not "
                 f"published in {model_id!r}. Falling back to the default fp32 file with "

--- a/gliner/model.py
+++ b/gliner/model.py
@@ -15,7 +15,7 @@ from torch import nn
 from packaging import version
 from safetensors import safe_open
 from transformers import AutoTokenizer
-from huggingface_hub import PyTorchModelHubMixin, snapshot_download
+from huggingface_hub import HfApi, PyTorchModelHubMixin, snapshot_download
 from torch.utils.data import DataLoader
 from safetensors.torch import save_file
 
@@ -327,6 +327,121 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
             f"model.{variant}.safetensors",
             f"model.{variant}.safetensors.index.json",
         ]
+
+    @classmethod
+    def _variant_available(
+        cls,
+        model_id: str,
+        variant: str,
+        revision: Optional[str] = None,
+        token: Union[str, bool, None] = None,
+        local_files_only: bool = False,
+    ) -> Optional[bool]:
+        """Probe whether ``model.{variant}.safetensors`` is published.
+
+        For local paths the probe is a disk check. For Hub repos it calls
+        ``HfApi().list_repo_files``.
+
+        Returns:
+            ``True`` / ``False`` when known, or ``None`` when availability
+            cannot be determined (offline, transient API failure, gated
+            repo without auth). Callers should treat ``None`` as
+            "uncertain — try the narrow download and let it fail loudly".
+        """
+        target = f"model.{variant}.safetensors"
+
+        model_dir = Path(model_id)
+        if model_dir.exists() and model_dir.is_dir():
+            return (model_dir / target).exists()
+
+        if local_files_only:
+            return None
+
+        try:
+            files = HfApi().list_repo_files(repo_id=model_id, revision=revision, token=token)
+        except Exception:
+            # The list of possible huggingface_hub errors here is wide
+            # (network, auth, repo not found, gated). Treat any failure as
+            # "availability unknown" and let the subsequent download path
+            # produce the canonical error if there really is a problem.
+            return None
+        return target in files
+
+    @classmethod
+    def _resolve_variant(
+        cls,
+        model_id: str,
+        variant: Optional[str],
+        revision: Optional[str] = None,
+        token: Union[str, bool, None] = None,
+        local_files_only: bool = False,
+    ) -> Optional[str]:
+        """Probe for variant availability; warn and fall back to ``None`` if missing.
+
+        When the publisher has uploaded ``model.{variant}.safetensors`` this
+        returns ``variant`` unchanged so the caller proceeds with the narrow
+        download (the I/O win). When the file is definitively absent, this
+        returns ``None`` and emits a ``UserWarning`` — the caller should fall
+        back to the default fp32 file plus an in-memory cast (via ``dtype=``).
+        Uncertain probes (``available is None``) pass through unchanged so
+        the narrow download is attempted.
+        """
+        if variant is None:
+            return None
+        available = cls._variant_available(
+            model_id, variant, revision=revision, token=token, local_files_only=local_files_only
+        )
+        if available is False:
+            warnings.warn(
+                f"variant={variant!r} requested but 'model.{variant}.safetensors' is not "
+                f"published in {model_id!r}. Falling back to the default fp32 file with "
+                f"dtype={variant!r} cast on read — bytes-on-the-wire are not reduced. To "
+                f"silence this, ask the publisher to upload the variant or pass variant=None.",
+                UserWarning,
+                stacklevel=3,
+            )
+            return None
+        return variant
+
+    @classmethod
+    def _resolve_model_file(cls, model_dir: Path, variant: Optional[str]) -> tuple:
+        """Pick the model file on disk, with graceful fallback if variant is missing.
+
+        Returns ``(model_file: Path, effective_variant: Optional[str])``.
+        ``effective_variant`` is ``None`` when we fell back from a requested
+        variant to the fp32 file — the caller already has ``torch_dtype`` set
+        from the variant, so cast-on-read still produces the right precision.
+
+        Raises:
+            FileNotFoundError: if no usable model file exists.
+        """
+        if variant is not None:
+            variant_file = model_dir / f"model.{variant}.safetensors"
+            if variant_file.exists():
+                return variant_file, variant
+            # Variant requested but missing — try fp32 fallback alongside.
+            fallback = model_dir / "model.safetensors"
+            if not fallback.exists():
+                fallback = model_dir / "pytorch_model.bin"
+            if fallback.exists():
+                warnings.warn(
+                    f"Variant file 'model.{variant}.safetensors' not found in {model_dir}; "
+                    f"loading '{fallback.name}' and casting to {variant} on read.",
+                    UserWarning,
+                    stacklevel=3,
+                )
+                return fallback, None
+            raise FileNotFoundError(
+                f"Neither 'model.{variant}.safetensors' nor 'model.safetensors' "
+                f"nor 'pytorch_model.bin' found in {model_dir}."
+            )
+        # No variant requested — original behavior.
+        model_file = model_dir / "model.safetensors"
+        if not model_file.exists():
+            model_file = model_dir / "pytorch_model.bin"
+        if not model_file.exists():
+            raise FileNotFoundError(f"No model file found in {model_dir}")
+        return model_file, None
 
     @classmethod
     def _parse_dtype(cls, dtype) -> Optional[torch.dtype]:
@@ -842,15 +957,17 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
                 reading, so the full fp32 copy is never materialized — peak
                 host memory is roughly half of the default path for bf16/fp16.
                 Prefer this over ``quantize`` for plain precision changes.
-            variant: If set (``"fp16"`` or ``"bf16"``), download and load
-                ``model.{variant}.safetensors`` instead of the default fp32
-                file. The variant file must already be published to the repo;
-                if missing, raises ``FileNotFoundError`` with a message pointing
-                at ``dtype=`` for the in-memory cast path. When ``variant`` is
-                set without an explicit ``dtype``, ``dtype`` is inferred from
-                the variant; passing both with mismatched precisions raises.
-                ``None`` (default) preserves the prior behavior (download the
-                fp32 file, optionally cast on read via ``dtype=``).
+            variant: If set (``"fp16"`` or ``"bf16"``), prefer
+                ``model.{variant}.safetensors`` over the default fp32 file.
+                Best-effort: the loader probes the Hub (or local path) for the
+                variant file before downloading. If it is published, only the
+                variant file is fetched (~half the bytes vs fp32) and loaded
+                directly. If it is not published, a ``UserWarning`` is emitted
+                and the loader falls back to the default fp32 file plus an
+                in-memory cast — same outcome as ``dtype={variant!r}`` alone,
+                no I/O win, no error. ``dtype`` is inferred from ``variant``
+                when not set; passing both with mismatched precisions raises.
+                ``None`` (default) preserves the prior behavior verbatim.
             load_onnx_model: Whether to load ONNX model instead of PyTorch.
             onnx_model_file: Path to ONNX model file.
             session_options: ONNX runtime session options.
@@ -876,6 +993,21 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
                 raise ValueError(
                     f"variant={variant!r} requires dtype={variant_dtype}; got dtype={torch_dtype}. "
                     f"Drop dtype= to inherit from variant, or unset variant= to load the default file."
+                )
+            # Probe Hub/disk for variant availability. If the file isn't
+            # published, this warns and returns None — we then fall back to
+            # the default fp32 download path with `torch_dtype` already set,
+            # so cast-on-read produces the requested precision (no I/O win,
+            # but the model still loads). Skip if a model_dir was provided
+            # by the caller (they've already resolved the location); the
+            # file-resolution step below handles missing files there.
+            if model_dir is None:
+                variant = cls._resolve_variant(
+                    model_id,
+                    variant,
+                    revision=revision,
+                    token=token,
+                    local_files_only=local_files_only,
                 )
 
         # Download or locate model
@@ -914,24 +1046,13 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
             tokenizer = cls._load_tokenizer(config, model_dir, cache_dir)
 
         if not load_onnx_model:
-            # Find model file. With variant=, only the requested variant counts —
-            # falling back to the default fp32 file would silently defeat the
-            # download savings and produce a model at a different precision than
-            # the caller asked for.
-            if variant is not None:
-                model_file = model_dir / f"model.{variant}.safetensors"
-                if not model_file.exists():
-                    raise FileNotFoundError(
-                        f"Variant file 'model.{variant}.safetensors' not found in {model_dir}. "
-                        f"This repo may not publish a {variant} variant. To load the default "
-                        f"file and cast in memory instead, drop variant= and pass dtype={variant!r}."
-                    )
-            else:
-                model_file = model_dir / "model.safetensors"
-                if not model_file.exists():
-                    model_file = model_dir / "pytorch_model.bin"
-                if not model_file.exists():
-                    raise FileNotFoundError(f"No model file found in {model_dir}")
+            # Find the model file. _resolve_model_file picks the variant file
+            # if present, falls back to the default fp32 file with a warning if
+            # the variant is missing (e.g. caller passed model_dir directly to
+            # a local path without a variant file). torch_dtype is already set
+            # from the variant earlier, so the cast-on-read in _load_state_dict
+            # still produces the requested precision after a fallback.
+            model_file, _ = cls._resolve_model_file(model_dir, variant)
 
             # Create model instance
             instance = cls(
@@ -4339,11 +4460,13 @@ class GLiNER(nn.Module, PyTorchModelHubMixin):
                 are cast during the state-dict read so the fp32 copy is never
                 fully materialized; prefer this over ``quantize`` for plain
                 precision changes.
-            variant: ``"fp16"`` / ``"bf16"`` to download
-                ``model.{variant}.safetensors`` instead of the default fp32
-                file. Requires the publisher to have uploaded the variant; see
-                ``GLiNER.from_pretrained`` docstring on the base class for the
-                full contract. ``None`` (default) preserves prior behavior.
+            variant: ``"fp16"`` / ``"bf16"`` to prefer
+                ``model.{variant}.safetensors`` over the default fp32 file.
+                Best-effort with graceful fallback: if the publisher uploaded
+                the variant, only that file is fetched; if not, warns and
+                falls back to fp32 + cast on read. See the base-class
+                ``from_pretrained`` docstring for the full contract.
+                ``None`` (default) preserves prior behavior.
             load_onnx_model: Whether to load ONNX model instead of PyTorch.
             onnx_model_file: Path to ONNX model file.
             max_length: Override max_length in config.
@@ -4365,8 +4488,24 @@ class GLiNER(nn.Module, PyTorchModelHubMixin):
         """
         # Canonicalize variant up front so it can narrow the download. The
         # outer ``GLiNER`` class doesn't inherit from ``BaseGLiNER``; reuse
-        # the helper directly so behavior stays in lockstep.
+        # the helpers directly so behavior stays in lockstep.
         normalized_variant = BaseGLiNER._normalize_variant(variant)
+        # Probe for availability and warn-and-fall-back to None if the variant
+        # file isn't published. The inner from_pretrained will see model_dir
+        # is already populated and skip its own probe — no double round-trip.
+        normalized_variant = BaseGLiNER._resolve_variant(
+            model_id,
+            normalized_variant,
+            revision=revision,
+            token=token,
+            local_files_only=local_files_only,
+        )
+        # If the probe downgraded variant -> None but the user asked for a
+        # specific variant, propagate the variant's dtype so the inner cast-on-
+        # read still produces the requested precision.
+        if variant is not None and normalized_variant is None and dtype is None:
+            original = BaseGLiNER._normalize_variant(variant)
+            dtype = BaseGLiNER._VARIANT_TO_DTYPE[original]
 
         model_dir = BaseGLiNER._download_model(
             model_id,

--- a/gliner/model.py
+++ b/gliner/model.py
@@ -319,19 +319,26 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
     def _variant_allow_patterns(variant: str) -> list:
         """Return ``snapshot_download(allow_patterns=...)`` for a variant.
 
-        The patterns include the variant safetensors file (and its sharded
-        index, if present) plus the configs and tokenizer assets every load
-        needs. The default ``model.safetensors`` and ``pytorch_model.bin`` are
-        deliberately excluded so the caller pays I/O only for the requested
-        variant.
+        Includes the single-file variant safetensors, the sharded variant
+        index, the actual sharded variant safetensors files, and the configs
+        and tokenizer assets every load needs. The default
+        ``model.safetensors`` and ``pytorch_model.bin`` are deliberately
+        excluded so the caller pays I/O only for the requested variant.
+
+        Sharded checkpoint convention (transformers-style):
+            ``model-00001-of-NNNNN.{variant}.safetensors``
+            ``model.{variant}.safetensors.index.json``
         """
         return [
             "*.json",
             "*.txt",
             "spiece.model",
             "sentencepiece.bpe.model",
+            # Single-file variant.
             f"model.{variant}.safetensors",
+            # Sharded variant: index file + per-shard files.
             f"model.{variant}.safetensors.index.json",
+            f"model-*-of-*.{variant}.safetensors",
         ]
 
     @classmethod
@@ -340,6 +347,7 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
         model_id: str,
         variant: str,
         revision: Optional[str] = None,
+        cache_dir: Optional[Union[str, Path]] = None,
         token: Union[str, bool, None] = None,
         local_files_only: bool = False,
     ) -> Optional[bool]:
@@ -375,8 +383,11 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
         # try_to_load_from_cache validates the repo_id format; an
         # HFValidationError here means the input isn't a valid repo_id at
         # all (e.g. a non-existent local path), so treat as uncertain.
+        # ``cache_dir`` must match what ``snapshot_download`` will use, or the
+        # probe and the actual download diverge (and we'd download the variant
+        # twice).
         try:
-            cached = try_to_load_from_cache(repo_id=model_id, filename=target, revision=revision)
+            cached = try_to_load_from_cache(repo_id=model_id, filename=target, revision=revision, cache_dir=cache_dir)
         except Exception:
             return None
         if isinstance(cached, str):
@@ -388,8 +399,16 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
 
         # 4. Try-and-recover via hf_hub_download. Success caches the file so
         # the subsequent snapshot_download reuses it (no double download).
+        # cache_dir must propagate so the probe and snapshot_download share
+        # the same store.
         try:
-            hf_hub_download(repo_id=model_id, filename=target, revision=revision, token=token)
+            hf_hub_download(
+                repo_id=model_id,
+                filename=target,
+                revision=revision,
+                cache_dir=cache_dir,
+                token=token,
+            )
             return True
         except EntryNotFoundError:
             return False
@@ -404,6 +423,7 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
         model_id: str,
         variant: Optional[str],
         revision: Optional[str] = None,
+        cache_dir: Optional[Union[str, Path]] = None,
         token: Union[str, bool, None] = None,
         local_files_only: bool = False,
     ) -> Optional[str]:
@@ -420,7 +440,12 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
         if variant is None:
             return None
         available = cls._variant_available(
-            model_id, variant, revision=revision, token=token, local_files_only=local_files_only
+            model_id,
+            variant,
+            revision=revision,
+            cache_dir=cache_dir,
+            token=token,
+            local_files_only=local_files_only,
         )
         if available is False:
             # TODO(strict-variant): once half-precision variant files have been
@@ -1046,6 +1071,7 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
                     model_id,
                     variant,
                     revision=revision,
+                    cache_dir=cache_dir,
                     token=token,
                     local_files_only=local_files_only,
                 )
@@ -4530,6 +4556,28 @@ class GLiNER(nn.Module, PyTorchModelHubMixin):
         # outer ``GLiNER`` class doesn't inherit from ``BaseGLiNER``; reuse
         # the helpers directly so behavior stays in lockstep.
         normalized_variant = BaseGLiNER._normalize_variant(variant)
+
+        # dtype-vs-variant consistency check MUST run before the probe.
+        # Otherwise, when the variant file is missing on the Hub,
+        # ``_resolve_variant`` downgrades to ``None`` and the inner
+        # ``from_pretrained``'s consistency check is skipped — silently
+        # accepting a ``variant="bf16", dtype="fp16"`` mismatch instead of
+        # raising as documented.
+        torch_dtype = BaseGLiNER._parse_dtype(dtype)
+        if normalized_variant is not None:
+            variant_dtype = BaseGLiNER._VARIANT_TO_DTYPE[normalized_variant]
+            if torch_dtype is None:
+                torch_dtype = variant_dtype
+                # Propagate the variant's dtype so the inner cast-on-read still
+                # produces the requested precision after a fallback.
+                dtype = variant_dtype
+            elif torch_dtype != variant_dtype:
+                raise ValueError(
+                    f"variant={normalized_variant!r} requires dtype={variant_dtype}; "
+                    f"got dtype={torch_dtype}. Drop dtype= to inherit from variant, "
+                    f"or unset variant= to load the default file."
+                )
+
         # Probe for availability and warn-and-fall-back to None if the variant
         # file isn't published. The inner from_pretrained will see model_dir
         # is already populated and skip its own probe — no double round-trip.
@@ -4537,15 +4585,10 @@ class GLiNER(nn.Module, PyTorchModelHubMixin):
             model_id,
             normalized_variant,
             revision=revision,
+            cache_dir=cache_dir,
             token=token,
             local_files_only=local_files_only,
         )
-        # If the probe downgraded variant -> None but the user asked for a
-        # specific variant, propagate the variant's dtype so the inner cast-on-
-        # read still produces the requested precision.
-        if variant is not None and normalized_variant is None and dtype is None:
-            original = BaseGLiNER._normalize_variant(variant)
-            dtype = BaseGLiNER._VARIANT_TO_DTYPE[original]
 
         model_dir = BaseGLiNER._download_model(
             model_id,

--- a/gliner/model.py
+++ b/gliner/model.py
@@ -268,6 +268,66 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
         "float": torch.float32,
     }
 
+    # Variants the loader knows how to *download* selectively. The default
+    # (fp32) is represented as `variant=None` and matches the canonical
+    # ``model.safetensors`` filename. fp16/bf16 map to the transformers
+    # convention ``model.{variant}.safetensors``.
+    _VARIANT_TO_DTYPE = {
+        "fp16": torch.float16,
+        "bf16": torch.bfloat16,
+    }
+    _VARIANT_ALIASES = {
+        "fp16": "fp16",
+        "float16": "fp16",
+        "half": "fp16",
+        "bf16": "bf16",
+        "bfloat16": "bf16",
+    }
+
+    @classmethod
+    def _normalize_variant(cls, variant) -> Optional[str]:
+        """Canonicalize a variant string to ``"fp16"``, ``"bf16"``, or ``None``.
+
+        ``None`` selects the default (fp32) ``model.safetensors``. Anything
+        else is canonicalized via :attr:`_VARIANT_ALIASES`. Unknown values —
+        including ``"fp32"`` and integer dtypes — raise ``ValueError`` with a
+        message pointing the caller at ``dtype=`` for in-memory casts.
+        """
+        if variant is None:
+            return None
+        if not isinstance(variant, str):
+            raise TypeError(f"variant must be str or None, got {type(variant).__name__}")
+        key = variant.lower()
+        if key in {"fp32", "float32", "float"}:
+            raise ValueError(
+                "variant='fp32' is not a separate download — drop variant= to load the default `model.safetensors`."
+            )
+        if key not in cls._VARIANT_ALIASES:
+            raise ValueError(
+                f"Unknown variant {variant!r}. Supported: {sorted(set(cls._VARIANT_ALIASES))}. "
+                f"For int8, use `quantize='int8'` (no separate download)."
+            )
+        return cls._VARIANT_ALIASES[key]
+
+    @staticmethod
+    def _variant_allow_patterns(variant: str) -> list:
+        """Return ``snapshot_download(allow_patterns=...)`` for a variant.
+
+        The patterns include the variant safetensors file (and its sharded
+        index, if present) plus the configs and tokenizer assets every load
+        needs. The default ``model.safetensors`` and ``pytorch_model.bin`` are
+        deliberately excluded so the caller pays I/O only for the requested
+        variant.
+        """
+        return [
+            "*.json",
+            "*.txt",
+            "spiece.model",
+            "sentencepiece.bpe.model",
+            f"model.{variant}.safetensors",
+            f"model.{variant}.safetensors.index.json",
+        ]
+
     @classmethod
     def _parse_dtype(cls, dtype) -> Optional[torch.dtype]:
         if dtype is None:
@@ -557,6 +617,7 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
         resume_download: bool = False,
         token: Union[str, bool, None] = None,
         local_files_only: bool = False,
+        variant: Optional[str] = None,
     ) -> Path:
         """
         Download model from HuggingFace Hub or use local directory.
@@ -570,6 +631,10 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
             resume_download: Resume interrupted downloads
             token: HF token
             local_files_only: Only use local files
+            variant: If set, restrict the download to ``model.{variant}.safetensors``
+                (plus configs/tokenizer assets) via ``snapshot_download``'s
+                ``allow_patterns``. Must be canonicalized via
+                :meth:`_normalize_variant` by the caller.
 
         Returns:
             Path to model directory
@@ -577,6 +642,7 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
         model_dir = Path(model_id)
 
         if not model_dir.exists():
+            allow_patterns = cls._variant_allow_patterns(variant) if variant else None
             model_dir = Path(
                 snapshot_download(
                     repo_id=model_id,
@@ -587,6 +653,7 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
                     resume_download=resume_download,
                     token=token,
                     local_files_only=local_files_only,
+                    allow_patterns=allow_patterns,
                 )
             )
 
@@ -738,6 +805,7 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
         compile_torch_model: Optional[bool] = False,
         quantize: Optional[str] = None,
         dtype: Optional[Union[str, torch.dtype]] = None,
+        variant: Optional[str] = None,
         load_onnx_model: Optional[bool] = False,
         onnx_model_file: Optional[str] = "model.onnx",
         session_options=None,
@@ -774,6 +842,15 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
                 reading, so the full fp32 copy is never materialized — peak
                 host memory is roughly half of the default path for bf16/fp16.
                 Prefer this over ``quantize`` for plain precision changes.
+            variant: If set (``"fp16"`` or ``"bf16"``), download and load
+                ``model.{variant}.safetensors`` instead of the default fp32
+                file. The variant file must already be published to the repo;
+                if missing, raises ``FileNotFoundError`` with a message pointing
+                at ``dtype=`` for the in-memory cast path. When ``variant`` is
+                set without an explicit ``dtype``, ``dtype`` is inferred from
+                the variant; passing both with mismatched precisions raises.
+                ``None`` (default) preserves the prior behavior (download the
+                fp32 file, optionally cast on read via ``dtype=``).
             load_onnx_model: Whether to load ONNX model instead of PyTorch.
             onnx_model_file: Path to ONNX model file.
             session_options: ONNX runtime session options.
@@ -786,10 +863,33 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
         Returns:
             Loaded model instance.
         """
+        # Resolve variant + dtype up front so the download path can be
+        # narrowed *before* hitting the network. Must happen before any
+        # snapshot_download call so allow_patterns can apply.
+        variant = cls._normalize_variant(variant)
+        torch_dtype = cls._parse_dtype(dtype)
+        if variant is not None:
+            variant_dtype = cls._VARIANT_TO_DTYPE[variant]
+            if torch_dtype is None:
+                torch_dtype = variant_dtype
+            elif torch_dtype != variant_dtype:
+                raise ValueError(
+                    f"variant={variant!r} requires dtype={variant_dtype}; got dtype={torch_dtype}. "
+                    f"Drop dtype= to inherit from variant, or unset variant= to load the default file."
+                )
+
         # Download or locate model
         if model_dir is None:
             model_dir = cls._download_model(
-                model_id, revision, cache_dir, force_download, proxies, resume_download, token, local_files_only
+                model_id,
+                revision,
+                cache_dir,
+                force_download,
+                proxies,
+                resume_download,
+                token,
+                local_files_only,
+                variant=variant,
             )
 
         # Load config
@@ -814,13 +914,24 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
             tokenizer = cls._load_tokenizer(config, model_dir, cache_dir)
 
         if not load_onnx_model:
-            # Find model file
-            model_file = model_dir / "model.safetensors"
-            if not model_file.exists():
-                model_file = model_dir / "pytorch_model.bin"
-
-            if not model_file.exists():
-                raise FileNotFoundError(f"No model file found in {model_dir}")
+            # Find model file. With variant=, only the requested variant counts —
+            # falling back to the default fp32 file would silently defeat the
+            # download savings and produce a model at a different precision than
+            # the caller asked for.
+            if variant is not None:
+                model_file = model_dir / f"model.{variant}.safetensors"
+                if not model_file.exists():
+                    raise FileNotFoundError(
+                        f"Variant file 'model.{variant}.safetensors' not found in {model_dir}. "
+                        f"This repo may not publish a {variant} variant. To load the default "
+                        f"file and cast in memory instead, drop variant= and pass dtype={variant!r}."
+                    )
+            else:
+                model_file = model_dir / "model.safetensors"
+                if not model_file.exists():
+                    model_file = model_dir / "pytorch_model.bin"
+                if not model_file.exists():
+                    raise FileNotFoundError(f"No model file found in {model_dir}")
 
             # Create model instance
             instance = cls(
@@ -829,7 +940,6 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
 
             cls._resize_token_embeddings(instance, config, tokenizer, resize_token_embeddings)
 
-            torch_dtype = cls._parse_dtype(dtype)
             if torch_dtype is not None:
                 # Pre-cast the random-init shell so the model never exists at
                 # fp32 alongside the loaded state dict. ``.to(floating_dtype)``
@@ -4192,6 +4302,7 @@ class GLiNER(nn.Module, PyTorchModelHubMixin):
         compile_torch_model: Optional[bool] = False,
         quantize: Optional[str] = None,
         dtype: Optional[Union[str, torch.dtype]] = None,
+        variant: Optional[str] = None,
         load_onnx_model: Optional[bool] = False,
         onnx_model_file: Optional[str] = "model.onnx",
         # Config overrides
@@ -4228,6 +4339,11 @@ class GLiNER(nn.Module, PyTorchModelHubMixin):
                 are cast during the state-dict read so the fp32 copy is never
                 fully materialized; prefer this over ``quantize`` for plain
                 precision changes.
+            variant: ``"fp16"`` / ``"bf16"`` to download
+                ``model.{variant}.safetensors`` instead of the default fp32
+                file. Requires the publisher to have uploaded the variant; see
+                ``GLiNER.from_pretrained`` docstring on the base class for the
+                full contract. ``None`` (default) preserves prior behavior.
             load_onnx_model: Whether to load ONNX model instead of PyTorch.
             onnx_model_file: Path to ONNX model file.
             max_length: Override max_length in config.
@@ -4244,21 +4360,25 @@ class GLiNER(nn.Module, PyTorchModelHubMixin):
             >>> model = GLiNER.from_pretrained("knowledgator/gliner-bi-small-v1.0")
             >>> model = GLiNER.from_pretrained("path/to/local/model", quantize="int8")
             >>> model = GLiNER.from_pretrained("urchade/gliner_small-v2.1", dtype="bf16")
+            >>> # If the repo publishes model.bf16.safetensors, download only that:
+            >>> model = GLiNER.from_pretrained("org/gliner_bf16-v1", variant="bf16")
         """
-        model_dir = Path(model_id)
-        if not model_dir.exists():
-            model_dir = Path(
-                snapshot_download(
-                    repo_id=model_id,
-                    revision=revision,
-                    cache_dir=cache_dir,
-                    force_download=force_download,
-                    proxies=proxies,
-                    resume_download=resume_download,
-                    token=token,
-                    local_files_only=local_files_only,
-                )
-            )
+        # Canonicalize variant up front so it can narrow the download. The
+        # outer ``GLiNER`` class doesn't inherit from ``BaseGLiNER``; reuse
+        # the helper directly so behavior stays in lockstep.
+        normalized_variant = BaseGLiNER._normalize_variant(variant)
+
+        model_dir = BaseGLiNER._download_model(
+            model_id,
+            revision=revision,
+            cache_dir=cache_dir,
+            force_download=force_download,
+            proxies=proxies,
+            resume_download=resume_download,
+            token=token,
+            local_files_only=local_files_only,
+            variant=normalized_variant,
+        )
 
         # Load config to determine model type
         config_file = model_dir / "gliner_config.json"
@@ -4294,6 +4414,7 @@ class GLiNER(nn.Module, PyTorchModelHubMixin):
             compile_torch_model=compile_torch_model,
             quantize=quantize,
             dtype=dtype,
+            variant=normalized_variant,
             max_length=max_length,
             max_width=max_width,
             post_fusion_schema=post_fusion_schema,

--- a/tests/test_quantize_and_dtype.py
+++ b/tests/test_quantize_and_dtype.py
@@ -5,6 +5,7 @@ public contracts on BaseGLiNER (``_parse_dtype``, ``_load_state_dict``) and
 ``model.quantize(...)`` via a lightweight fake subclass.
 """
 
+import warnings
 from pathlib import Path
 
 import torch
@@ -337,3 +338,102 @@ class TestVariantDtypeConsistency:
                 variant="bf16",
                 dtype=torch.int8,
             )
+
+
+class TestVariantAvailable:
+    """``_variant_available`` probe for variant file presence."""
+
+    def _safetensors_at(self, path: Path) -> None:
+        save_file({"weight": torch.randn(2, 2)}, str(path))
+
+    def test_local_dir_with_variant_returns_true(self, tmp_path: Path):
+        self._safetensors_at(tmp_path / "model.bf16.safetensors")
+        assert BaseGLiNER._variant_available(str(tmp_path), "bf16") is True
+
+    def test_local_dir_without_variant_returns_false(self, tmp_path: Path):
+        self._safetensors_at(tmp_path / "model.safetensors")
+        # default fp32 is there, but no bf16 file
+        assert BaseGLiNER._variant_available(str(tmp_path), "bf16") is False
+
+    def test_local_dir_with_only_fp16_does_not_match_bf16(self, tmp_path: Path):
+        self._safetensors_at(tmp_path / "model.fp16.safetensors")
+        assert BaseGLiNER._variant_available(str(tmp_path), "bf16") is False
+        assert BaseGLiNER._variant_available(str(tmp_path), "fp16") is True
+
+    def test_nonexistent_path_with_local_files_only_returns_none(self, tmp_path: Path):
+        """No local dir + local_files_only=True should not hit the network."""
+        nonexistent = tmp_path / "does_not_exist"
+        assert BaseGLiNER._variant_available(str(nonexistent), "bf16", local_files_only=True) is None
+
+
+class TestResolveVariantFallback:
+    """``_resolve_variant`` warns and downgrades to None when variant is missing."""
+
+    def test_passthrough_when_none(self):
+        # No probe needed for variant=None; returns None silently.
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            assert BaseGLiNER._resolve_variant("any/repo", None) is None
+            assert [w for w in caught if "variant" in str(w.message).lower()] == []
+
+    def test_passthrough_when_available(self, tmp_path: Path):
+        save_file({"weight": torch.randn(2, 2)}, str(tmp_path / "model.bf16.safetensors"))
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            out = BaseGLiNER._resolve_variant(str(tmp_path), "bf16")
+            assert out == "bf16"
+            assert [w for w in caught if "variant" in str(w.message).lower()] == []
+
+    def test_warns_and_returns_none_when_unavailable(self, tmp_path: Path):
+        save_file({"weight": torch.randn(2, 2)}, str(tmp_path / "model.safetensors"))
+        # Variant file isn't there; expect warn + None.
+        with pytest.warns(UserWarning, match="not published"):
+            out = BaseGLiNER._resolve_variant(str(tmp_path), "bf16")
+        assert out is None
+
+
+class TestResolveModelFile:
+    """``_resolve_model_file`` picks the right file with graceful fallback."""
+
+    def test_default_path_picks_safetensors(self, tmp_path: Path):
+        save_file({"weight": torch.randn(2, 2)}, str(tmp_path / "model.safetensors"))
+        path, eff = BaseGLiNER._resolve_model_file(tmp_path, variant=None)
+        assert path == tmp_path / "model.safetensors"
+        assert eff is None
+
+    def test_default_path_falls_back_to_pytorch_bin(self, tmp_path: Path):
+        torch.save({}, str(tmp_path / "pytorch_model.bin"))
+        path, eff = BaseGLiNER._resolve_model_file(tmp_path, variant=None)
+        assert path == tmp_path / "pytorch_model.bin"
+        assert eff is None
+
+    def test_default_path_no_file_raises(self, tmp_path: Path):
+        with pytest.raises(FileNotFoundError, match="No model file"):
+            BaseGLiNER._resolve_model_file(tmp_path, variant=None)
+
+    def test_variant_present_returns_variant(self, tmp_path: Path):
+        save_file({"weight": torch.randn(2, 2)}, str(tmp_path / "model.bf16.safetensors"))
+        save_file({"weight": torch.randn(2, 2)}, str(tmp_path / "model.safetensors"))
+        path, eff = BaseGLiNER._resolve_model_file(tmp_path, variant="bf16")
+        assert path == tmp_path / "model.bf16.safetensors"
+        assert eff == "bf16"
+
+    def test_variant_missing_warns_and_falls_back_to_safetensors(self, tmp_path: Path):
+        save_file({"weight": torch.randn(2, 2)}, str(tmp_path / "model.safetensors"))
+        with pytest.warns(UserWarning, match="not found"):
+            path, eff = BaseGLiNER._resolve_model_file(tmp_path, variant="bf16")
+        assert path == tmp_path / "model.safetensors"
+        # effective_variant must be None so caller knows we fell back
+        # (torch_dtype is already set from the variant earlier in from_pretrained)
+        assert eff is None
+
+    def test_variant_missing_falls_back_to_pytorch_bin(self, tmp_path: Path):
+        torch.save({}, str(tmp_path / "pytorch_model.bin"))
+        with pytest.warns(UserWarning, match="not found"):
+            path, eff = BaseGLiNER._resolve_model_file(tmp_path, variant="bf16")
+        assert path == tmp_path / "pytorch_model.bin"
+        assert eff is None
+
+    def test_variant_missing_with_no_fallback_raises(self, tmp_path: Path):
+        with pytest.raises(FileNotFoundError, match="Neither"):
+            BaseGLiNER._resolve_model_file(tmp_path, variant="bf16")

--- a/tests/test_quantize_and_dtype.py
+++ b/tests/test_quantize_and_dtype.py
@@ -214,3 +214,126 @@ class TestFromPretrainedQuantizeTrueRejection:
         # ``_FakeModel("cpu").quantize(True)`` which also raises.
         with pytest.raises(TypeError, match="expects a string"):
             _FakeModel("cpu").quantize(True)
+
+
+class TestNormalizeVariant:
+    """``variant=`` canonicalization for selective downloads."""
+
+    def test_none_is_default(self):
+        assert BaseGLiNER._normalize_variant(None) is None
+
+    @pytest.mark.parametrize(
+        "alias,canonical",
+        [
+            ("fp16", "fp16"),
+            ("float16", "fp16"),
+            ("half", "fp16"),
+            ("FP16", "fp16"),  # case-insensitive
+            ("bf16", "bf16"),
+            ("bfloat16", "bf16"),
+            ("BFloat16", "bf16"),
+        ],
+    )
+    def test_aliases_canonicalize(self, alias, canonical):
+        assert BaseGLiNER._normalize_variant(alias) == canonical
+
+    @pytest.mark.parametrize("v", ["fp32", "float32", "float"])
+    def test_fp32_explicitly_rejected(self, v):
+        """fp32 is the default download — there's no separate variant file."""
+        with pytest.raises(ValueError, match="not a separate download"):
+            BaseGLiNER._normalize_variant(v)
+
+    def test_int8_rejected_with_pointer(self):
+        """int8 isn't a precision variant; the error should redirect to quantize=."""
+        with pytest.raises(ValueError, match=r"quantize='int8'"):
+            BaseGLiNER._normalize_variant("int8")
+
+    def test_unknown_string_lists_supported(self):
+        with pytest.raises(ValueError, match="Supported"):
+            BaseGLiNER._normalize_variant("qint4")
+
+    @pytest.mark.parametrize("bad", [123, 3.14, [], object()])
+    def test_bad_type_raises_typeerror(self, bad):
+        with pytest.raises(TypeError, match=r"str or None"):
+            BaseGLiNER._normalize_variant(bad)
+
+
+class TestVariantAllowPatterns:
+    """The ``allow_patterns`` we hand to ``snapshot_download``."""
+
+    def test_includes_only_requested_variant_safetensors(self):
+        patterns = BaseGLiNER._variant_allow_patterns("bf16")
+        assert "model.bf16.safetensors" in patterns
+        # Default and other variants must NOT be in the allow list, otherwise
+        # snapshot_download would still pull them.
+        assert "model.safetensors" not in patterns
+        assert "model.fp16.safetensors" not in patterns
+        assert "pytorch_model.bin" not in patterns
+
+    def test_includes_sharded_index(self):
+        patterns = BaseGLiNER._variant_allow_patterns("fp16")
+        assert "model.fp16.safetensors.index.json" in patterns
+
+    def test_includes_configs_and_tokenizer(self):
+        """Tokenizer / config files must always come down."""
+        patterns = BaseGLiNER._variant_allow_patterns("bf16")
+        # ``*.json`` covers gliner_config.json, tokenizer_config.json,
+        # special_tokens_map.json, added_tokens.json.
+        assert "*.json" in patterns
+        # SentencePiece-style tokenizers ship .model / .txt files.
+        assert "spiece.model" in patterns
+        assert "sentencepiece.bpe.model" in patterns
+        assert "*.txt" in patterns
+
+    def test_fp16_and_bf16_differ_only_in_variant_filename(self):
+        a = set(BaseGLiNER._variant_allow_patterns("fp16"))
+        b = set(BaseGLiNER._variant_allow_patterns("bf16"))
+        diff = a.symmetric_difference(b)
+        assert diff == {
+            "model.fp16.safetensors",
+            "model.bf16.safetensors",
+            "model.fp16.safetensors.index.json",
+            "model.bf16.safetensors.index.json",
+        }
+
+
+class TestVariantDtypeConsistency:
+    """``variant=`` and ``dtype=`` must agree (or only one set).
+
+    The mismatch check fires before any download/config/model construction,
+    so we can test it on the abstract ``BaseGLiNER`` without a real checkpoint.
+    """
+
+    def test_mismatch_raises_value_error(self, tmp_path: Path):
+        """variant='bf16' with dtype='fp16' is contradictory."""
+        with pytest.raises(ValueError, match="variant='bf16' requires"):
+            BaseGLiNER.from_pretrained(
+                model_id=str(tmp_path),
+                model_dir=tmp_path,
+                variant="bf16",
+                dtype="fp16",
+            )
+
+    def test_aliases_normalize_before_compare(self, tmp_path: Path):
+        """variant='bfloat16' + dtype='bf16' must NOT raise on dtype mismatch.
+
+        Both canonicalize to bf16. The call still fails (no config in tmp_path)
+        but with a different error — proving the consistency check passed.
+        """
+        with pytest.raises(FileNotFoundError, match="config"):
+            BaseGLiNER.from_pretrained(
+                model_id=str(tmp_path),
+                model_dir=tmp_path,
+                variant="bfloat16",
+                dtype="bf16",
+            )
+
+    def test_int_dtype_against_variant_rejected_by_dtype_parser(self, tmp_path: Path):
+        """variant='bf16' with dtype=torch.int8 should fail at dtype parsing."""
+        with pytest.raises(ValueError, match="floating-point"):
+            BaseGLiNER.from_pretrained(
+                model_id=str(tmp_path),
+                model_dir=tmp_path,
+                variant="bf16",
+                dtype=torch.int8,
+            )

--- a/tests/test_quantize_and_dtype.py
+++ b/tests/test_quantize_and_dtype.py
@@ -13,6 +13,7 @@ import pytest
 from torch import nn
 from safetensors.torch import save_file
 
+from gliner import GLiNER
 from gliner.model import BaseGLiNER
 
 
@@ -295,7 +296,25 @@ class TestVariantAllowPatterns:
             "model.bf16.safetensors",
             "model.fp16.safetensors.index.json",
             "model.bf16.safetensors.index.json",
+            # Sharded variant patterns must also differ between fp16 and bf16,
+            # otherwise large multi-file checkpoints can't pull only the
+            # requested precision's shards.
+            "model-*-of-*.fp16.safetensors",
+            "model-*-of-*.bf16.safetensors",
         }
+
+    def test_includes_sharded_safetensors_pattern(self):
+        """Sharded variant checkpoints place tensor data in
+        ``model-XXXXX-of-YYYYY.{variant}.safetensors`` files; without the
+        wildcard pattern the index would download but the actual shards
+        would be filtered out.
+        """
+        patterns = BaseGLiNER._variant_allow_patterns("bf16")
+        assert "model-*-of-*.bf16.safetensors" in patterns
+        # Wrong variant must not slip through the sharded match.
+        assert "model-*-of-*.fp16.safetensors" not in patterns
+        # Default-variant shards must still be excluded.
+        assert "model-*-of-*.safetensors" not in patterns
 
 
 class TestVariantDtypeConsistency:
@@ -337,6 +356,25 @@ class TestVariantDtypeConsistency:
                 model_dir=tmp_path,
                 variant="bf16",
                 dtype=torch.int8,
+            )
+
+    def test_outer_dispatcher_mismatch_raises_before_probe(self, tmp_path: Path):
+        """Codex review finding: the outer ``GLiNER.from_pretrained`` used to
+        run the variant probe before checking dtype/variant consistency, so
+        when the variant file was missing on the Hub the consistency check
+        was skipped and a ``variant='bf16', dtype='fp16'`` mismatch would
+        load fp16 silently. This test guards the regression by checking
+        the mismatch raises even when the model_id is a non-existent path
+        (which would otherwise be caught later by the download step).
+        """
+        # tmp_path has no gliner_config.json; if the consistency check runs
+        # first, we get a ValueError. If it runs after the probe (the bug),
+        # we'd get a FileNotFoundError or warning instead.
+        with pytest.raises(ValueError, match="variant='bf16' requires"):
+            GLiNER.from_pretrained(
+                model_id=str(tmp_path),
+                variant="bf16",
+                dtype="fp16",
             )
 
 


### PR DESCRIPTION
# Add `variant=` to `from_pretrained` for selective half-precision downloads

## Why

`dtype="bf16"` already loads at the target precision, but **it only casts in memory** — the file pulled from the Hub is still fp32. For `gliner_medium-v2.1` that's 745 MB on the wire whether you ask for fp32, fp16, or bf16.

For cold-start / serverless deployments (Lambda, Cloud Run, Modal, autoscaled k8s), wire bytes are usually a bigger cold-start cost than the post-load cast — so a way to download only the half-precision file is the missing lever.

I benchmarked the existing `dtype=` machinery on this branch (n=12, Welch t-tested, RTX 5090) before writing this: GPU peak memory drops ~37% (935 → 585 MB) but wall-clock load time **does not move** because disk I/O and per-tensor cast work are unchanged. `variant="bf16"` is the change that actually halves the bytes — turning a memory optimization into a latency one too, *when* the publisher has uploaded a half-precision file.

## What this PR adds

A new `variant=` argument on both `BaseGLiNER.from_pretrained` and the outer `GLiNER.from_pretrained` dispatcher, following the [`transformers` convention](https://huggingface.co/docs/transformers/main_classes/model#transformers.PreTrainedModel.from_pretrained.variant) of `model.{variant}.safetensors`:

```python
GLiNER.from_pretrained("org/gliner_bf16-v1", variant="bf16")
```

The flag is a **best-effort optimization hint**, not a hard requirement. Before downloading, the loader probes the location (`Path.exists()` for local paths, `HfApi().list_repo_files()` for Hub repos) to see if the variant is published. The behavior fans out from there:

| repo state | request | bytes downloaded | model dtype | warning |
|---|---|---|---|---|
| has `model.bf16.safetensors` | `variant="bf16"` | ~370 MB (variant only) | bf16 | none |
| has only `model.safetensors` | `variant="bf16"` | ~745 MB (fp32) | bf16 (cast on read) | UserWarning |
| has only `model.safetensors` | `dtype="bf16"` | ~745 MB (fp32) | bf16 (cast on read) | none |
| local dir missing variant | `variant="bf16"` | n/a | bf16 (cast on read) | UserWarning |
| `variant=None` (default) | unchanged | ~745 MB (fp32) | fp32 | none |

This means the change is **safe to ship before any variant files exist on the Hub**: today's repos all fall into row 2 (warn + fp32 download + cast on read = same outcome as `dtype="bf16"` alone). Once a publisher uploads `model.bf16.safetensors`, the same caller transparently moves to row 1 and gets the I/O win — no code change on the user side.

## Mechanism

Three small helpers added to `BaseGLiNER`:

- **`_variant_available(model_id, variant, ...)`** — probes for variant publication using the `transformers` / `huggingface_hub` idiom. Resolution order: (1) local directory → `Path.exists()`; (2) HF cache → `try_to_load_from_cache` (pure local, no network); (3) `local_files_only=True` → return `None` (uncertain); (4) `hf_hub_download` with `EntryNotFoundError` catch (success caches the file so the subsequent narrowed download reuses it; no double download). **Warm-cache repeat loads pay zero Hub round-trips.**
- **`_resolve_variant(...)`** — calls the probe; on definitive miss, emits a `UserWarning` and returns `None` (the caller falls back to the broad download with `dtype` already set to the variant's target dtype).
- **`_resolve_model_file(model_dir, variant)`** — second-line fallback at file-resolution time. Catches the case where a caller passes a local `model_dir` that lacks the variant file: warns, loads `model.safetensors` instead, hands `effective_variant=None` back so the caller knows we fell back.

Both `from_pretrained` entry points run the probe **before** `snapshot_download`, so the broad download is avoided when the variant isn't published. When the variant is present, `allow_patterns` narrows the download to just `model.{variant}.safetensors` (plus configs and tokenizer assets). API surface and probe mechanism match `transformers.PreTrainedModel.from_pretrained(variant=...)`; only the **strictness** differs (see below).

## Validation

Up-front checks that fire before any I/O:

| input | outcome |
|---|---|
| `variant="bf16", dtype="fp16"` | `ValueError` — explicit mismatch |
| `variant="fp32"` | `ValueError` — fp32 is the default file, not a separate variant |
| `variant="int8"` | `ValueError` pointing at `quantize="int8"` |
| Unknown variant string | `ValueError` listing supported values |
| `variant=` with non-string type | `TypeError` |

Aliases (`"float16"`, `"half"`, `"bfloat16"`, case-insensitive) canonicalize before comparison, so `variant="bfloat16", dtype="bf16"` is fine, not a mismatch.

## One pre-existing behavior diff to flag

`_parse_dtype(dtype)` now runs *before* the download/config/instance-creation steps (it has to, so the consistency check with `variant` can fire before any I/O). Previously, an invalid `dtype=` value passed alongside `load_onnx_model=True` was silently ignored; now it raises. ONNX paths shouldn't be passing dtype anyway, so this strictly improves error reporting, but it's a visible diff if anyone was relying on the silent ignore.

## Files changed

- **`gliner/model.py`** — `_VARIANT_TO_DTYPE` and `_VARIANT_ALIASES` dicts; `_normalize_variant`, `_variant_allow_patterns`, `_variant_available`, `_resolve_variant`, `_resolve_model_file` helpers. `variant=` plumbed through `_download_model`, the inner `BaseGLiNER.from_pretrained`, and the outer `GLiNER.from_pretrained`. `HfApi` lifted to module-top imports.
- **`tests/test_quantize_and_dtype.py`** — adds `TestNormalizeVariant`, `TestVariantAllowPatterns`, `TestVariantDtypeConsistency`, `TestVariantAvailable`, `TestResolveVariantFallback`, `TestResolveModelFile` (38 new cases). **88 tests passing total**, ruff lint and format clean.
- **`docs/usage.md`** — new "Selective download (`variant`)" subsection under the existing `dtype=` section, describing the soft-fallback semantics and behavior matrix.

No public-API breakage. `variant` is `Optional[str] = None`.

## Test plan

- [x] `pytest tests/test_quantize_and_dtype.py` — 88 passed
- [x] `ruff check` and `ruff format --check` clean on all touched files
- [x] End-to-end smoke against the cached `urchade/gliner_medium-v2.1`:
  - **Default** (`variant=None, dtype="fp16"`) loads as fp16 — regression check on the unchanged path
  - **Variant requested, file missing on Hub** (`variant="bf16"` against the real Hub repo) → `_variant_available` correctly returns `False`, `_resolve_variant` emits the warning and returns `None`, model loads as bf16 via fp32 download + cast on read
  - **Variant requested, file present** (against a hand-built bf16 file in `/tmp` that's exactly 372 MB vs the 744 MB fp32) → narrow download path, model loads as bf16, no warning
  - **Mismatch** (`variant="bf16", dtype="fp16"`) → `ValueError` before any I/O
  - **`variant="fp32"`** → `ValueError` (not a separate download)
  - **Alias** (`variant="bfloat16"`) → equivalent to `variant="bf16"`
- [x] `_variant_available` against a real Hub repo without the variant returns `False` (one HfApi round-trip)
- [x] `_variant_available` against a nonexistent repo returns `None` (graceful uncertain-state)

## What the GLiNER project owners need to do for users to actually benefit

The code change alone gives users the *ability* to consume variant files. But almost every GLiNER repo on the Hub today ships only the default fp32 `model.safetensors` — so to actually move the cold-start needle, **publishers need to upload the half-precision variants**. Concrete suggestions:

1. **Publish bf16 / fp16 variants alongside the fp32 file** for the flagship models (`urchade/gliner_small-v2.1`, `gliner_medium-v2.1`, `gliner_large-v2.1`, the bi-encoder variants):

   ```python
   from safetensors.torch import save_file
   import torch

   model = GLiNER.from_pretrained("...")  # fp32
   sd = model.model.state_dict()

   save_file(
       {k: v.to(torch.bfloat16) if v.is_floating_point() else v for k, v in sd.items()},
       "model.bf16.safetensors",
   )
   save_file(
       {k: v.to(torch.float16) if v.is_floating_point() else v for k, v in sd.items()},
       "model.fp16.safetensors",
   )
   ```

   Both files go in the same Hub repo as `model.safetensors`. No retraining, no quality change beyond the standard rounding.

2. **Decide a default for new releases.** Two reasonable policies:
   - "Always ship all three (fp32, fp16, bf16)" — costs ~2× repo storage but every user opts into what they want.
   - "Ship fp32 + bf16 only" — bf16 is the modern default and fp16 is mostly legacy hardware (pre-Ampere).

   Recommendation: ship fp32 + bf16. Storage is cheap, most GLiNER inference users are on hardware that prefers bf16.

3. **Update the README example block** to show `variant=` as the primary path for newly released models. (The PR doesn't change the README — adding it before any variant files are published would only show users a one-line warning, defeating the point.)

4. **Optional but useful:** add a CI step that round-trips variant files against the fp32 reference (max-abs-error within rounding tolerance). Trivial test, catches publish-time mistakes.

5. **Document the convention** in the model-publishing section of the README — `model.{variant}.safetensors`, transformers-style.

The change is a no-op for any existing repo without variant files, so it can ship safely before publishers catch up; the soft-fallback design means there's no flag-day where users have to upgrade in lockstep with publishers.

## Followups (not in this PR)

- **Flip `variant=` to strict (HF-compatible) once variants are published.** A `TODO(strict-variant)` comment is parked in `_resolve_variant`. `transformers.PreTrainedModel.from_pretrained(variant=...)` raises `EntryNotFoundError` when the variant file isn't published; this PR ships a soft-fallback (warn + use the default file) instead, deliberately, because at PR-merge time no GLiNER repo on the Hub had a variant file. Once the flagship models above ship variants, follow up by removing the soft-fallback so the surface matches transformers' strictness — same API names, same behavior, less code, less surprise for users coming from HF.
- **Publish actual bf16 variants** for the flagship models on the Hub — the project-owner work above; this is the change that turns the new code path into measurable cold-start savings for users (and unblocks the strict-variant flip).
- **`gliner.serve` CLI `--variant` flag.** The serving layer is exactly the cold-start use case, but the CLI in `gliner/serve/__main__.py` currently only exposes `--dtype` and `--quantization`. Adding `--variant` is ~10 lines of arg-parser plumbing plus a docs update; deliberately scoped out of this PR to keep the diff focused on `from_pretrained`, and easier to motivate once at least one variant file has been published.
- **Sharded variant safetensors.** The current loader handles single-file safetensors; `_variant_allow_patterns` already includes `model.{variant}.safetensors.index.json` for forward compatibility, but `_load_state_dict` would need to learn to read sharded safetensors before this is end-to-end useful. Out of scope here.
