### PR TITLE
Add low_cpu_mem_usage=True to from_pretrained for ~2x faster cold starts

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -392,6 +392,36 @@ Accepted values: `"fp16"` / `"float16"` / `"half"`, `"bf16"` / `"bfloat16"`, `"f
 
 `dtype` covers plain precision changes (bf16/fp16/fp32). For int8 / torchao / CPU dynamic quantization, keep using `quantize` (see below). The two can be combined if desired.
 
+#### Skipping the random-init shell (`low_cpu_mem_usage`)
+
+`dtype=` lowers peak memory but doesn't speed up the *load itself* — even with `dtype="bf16"`, GLiNER still allocates a fp32 random-initialized model shell, runs Kaiming/Xavier init over every parameter, casts the whole thing to bf16, then overwrites every value with the loaded weights. All of that init work is thrown away.
+
+Pass `low_cpu_mem_usage=True` to skip it: the model graph is built under `torch.device("meta")` (shape descriptors only, no allocation, no random init), the state dict is read at the target precision, and `load_state_dict(assign=True)` swaps the loaded tensors directly into the meta-shell parameter slots in one pass.
+
+```python
+model = GLiNER.from_pretrained(
+    "urchade/gliner_medium-v2.1",
+    dtype="bf16",
+    low_cpu_mem_usage=True,
+    map_location="cuda",
+)
+```
+
+Measured on `gliner_medium-v2.1` on an RTX 5090 (n=12 reps, Welch t-tested, OS page cache warmed):
+
+| path | mean load time | speedup | peak host RSS delta |
+|---|---|---|---|
+| baseline (cuda, bf16) | 3.16 s | 1.0× | 1361 MB |
+| `low_cpu_mem_usage=True` (cuda, bf16) | **1.61 s** | **1.96×** | 1004 MB |
+| baseline (cpu, bf16) | 3.30 s | 1.0× | 1597 MB |
+| `low_cpu_mem_usage=True` (cpu, bf16) | **1.60 s** | **2.06×** | 1225 MB |
+| baseline (cpu, fp32) | 3.04 s | 1.0× | 1598 MB |
+| `low_cpu_mem_usage=True` (cpu, fp32) | **1.45 s** | **2.10×** | 170 MB |
+
+About **1.5 seconds saved on every cold start**, plus 23–89% lower peak host RSS depending on dtype (the fp32 case is dramatic because safetensors mmaps the on-disk file and we never copy it into anonymous memory). Loaded parameters are bit-identical to the standard path — verified across 224 parameters and 1 buffer (`position_ids`, re-materialized after assign).
+
+Default is `False` while the path matures — enable it explicitly when cold-start latency or peak host memory matters. `low_cpu_mem_usage` stacks with `dtype=` (use them together) and is independent of `quantize=` and `compile_torch_model=`.
+
 ### Quantization, Compilation & FlashDeBERTa
 
 Combine `dtype="fp16"` (or `"bf16"`) with `compile_torch_model=True` for up to ~1.9x faster GPU inference with zero quality loss:

--- a/gliner/model.py
+++ b/gliner/model.py
@@ -900,33 +900,61 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
                 # Read state dict (cast on read if dtype was set), then swap
                 # tensors directly into the meta-shell parameter slots.
                 state_dict = cls._load_state_dict(model_file, map_location, dtype=torch_dtype)
-                meta_instance.model.load_state_dict(state_dict, assign=True, strict=strict)
+                incompat = meta_instance.model.load_state_dict(state_dict, assign=True, strict=strict)
                 del state_dict
 
                 # Materialize non-persistent buffers (position_ids etc.) that
                 # the state dict didn't carry.
                 _materialized, unrecognized = cls._materialize_meta_buffers(meta_instance.model)
 
-                if unrecognized:
-                    # Buffers we don't know how to recompute (e.g. RoPE inv_freq
-                    # whose base varies per-architecture). The meta-init load
-                    # would produce wrong inference; fall back to the standard
-                    # path so the user gets a correct model. Cost is one full
-                    # standard load; benefit is no silent correctness bug.
-                    short_names = sorted({n.rsplit(".", 1)[-1] for n in unrecognized})
+                # Detect parameters left on meta. With strict=True, missing
+                # keys would have raised at load_state_dict; with strict=False
+                # (the default) they don't, leaving the parameter on the meta
+                # device. The standard path keeps random-init values for these
+                # params, which is what the caller would have seen without
+                # low_cpu_mem_usage=True. The subsequent .to(map_location)
+                # would otherwise raise ``NotImplementedError: Cannot copy out
+                # of meta tensor`` and fail the load entirely.
+                meta_param_names = [n for n, p in meta_instance.model.named_parameters() if p.is_meta]
+
+                if unrecognized or meta_param_names:
+                    # Cases that meta-init can't safely handle: unrecognized
+                    # non-persistent buffers (e.g. RoPE inv_freq whose base
+                    # varies per-architecture), or parameters that the state
+                    # dict didn't supply (strict=False + missing keys). Fall
+                    # back to the standard load path — cost is one full
+                    # standard load; benefit is no silent correctness bug
+                    # and no spurious crash on .to(map_location).
+                    if unrecognized:
+                        short_names = sorted({n.rsplit(".", 1)[-1] for n in unrecognized})
+                        reason = (
+                            f"the model has non-persistent buffer(s) {short_names} that "
+                            f"_materialize_meta_buffers does not recognize "
+                            f"(e.g. RoPE inv_freq for ModernBERT)"
+                        )
+                    else:
+                        # Truncate to keep the warning readable; the missing-key
+                        # set can be large for genuinely incomplete checkpoints.
+                        sample = sorted(meta_param_names)[:5]
+                        more = f" (and {len(meta_param_names) - 5} more)" if len(meta_param_names) > 5 else ""
+                        reason = (
+                            f"the checkpoint is missing parameter(s) {sample}{more}; "
+                            f"the standard load path would have kept the random-init "
+                            f"values for these"
+                        )
                     warnings.warn(
-                        f"low_cpu_mem_usage=True is not supported for this architecture: "
-                        f"the model has non-persistent buffer(s) {short_names} that "
-                        f"_materialize_meta_buffers does not recognize "
-                        f"(e.g. RoPE inv_freq for ModernBERT). Falling back to the "
-                        f"standard load path so inference is correct. Pass "
-                        f"low_cpu_mem_usage=False to silence this warning.",
+                        f"low_cpu_mem_usage=True is not supported for this load: "
+                        f"{reason}. Falling back to the standard load path so "
+                        f"inference is correct. Pass low_cpu_mem_usage=False to "
+                        f"silence this warning.",
                         UserWarning,
                         stacklevel=2,
                     )
                     del meta_instance
                 else:
-                    # All buffers recognized — meta path succeeded.
+                    # All buffers recognized and all params materialized —
+                    # meta path succeeded.
+                    del incompat
                     meta_instance.model.to(map_location)
                     instance = meta_instance
 

--- a/gliner/model.py
+++ b/gliner/model.py
@@ -510,6 +510,50 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
 
         return cls._set_tokenizer_spec_tokens(tokenizer)
 
+    @staticmethod
+    def _materialize_meta_buffers(module: nn.Module) -> list:
+        """Re-materialize non-persistent buffers left on meta after assign-load.
+
+        Walks the module tree and replaces any buffer still on the meta device
+        after a meta-init + ``load_state_dict(assign=True)`` sequence.
+
+        Non-persistent buffers (registered with ``persistent=False``, e.g.
+        DeBERTa's ``position_ids``) are not in the saved state dict, so they
+        survive as meta tensors after the load. This helper restores them to
+        their canonical computed values.
+
+        Returns a list of buffer names that were materialized — useful for
+        tests and for warning on unknown patterns.
+        """
+        materialized = []
+        for name, buf in list(module.named_buffers()):
+            if not buf.is_meta:
+                continue
+            *parents, leaf = name.split(".")
+            parent_mod = module
+            for p in parents:
+                parent_mod = getattr(parent_mod, p)
+            if leaf == "position_ids":
+                # Standard transformers convention: arange(0, max_pos).expand(1, -1)
+                value = torch.arange(0, buf.shape[-1], dtype=buf.dtype).unsqueeze(0).contiguous()
+                parent_mod.register_buffer(leaf, value, persistent=False)
+                materialized.append(name)
+            else:
+                # Unknown non-persistent buffer — fall back to zeros and warn.
+                # If a caller hits this, the architecture has a buffer pattern
+                # we don't recognize; the user should either disable
+                # ``low_cpu_mem_usage`` or extend this method.
+                warnings.warn(
+                    f"low_cpu_mem_usage materialized unknown non-persistent buffer "
+                    f"{name!r} as zeros. Inference may be incorrect for this module. "
+                    f"Pass low_cpu_mem_usage=False to disable the meta-init path.",
+                    UserWarning,
+                    stacklevel=3,
+                )
+                parent_mod.register_buffer(leaf, torch.zeros(buf.shape, dtype=buf.dtype), persistent=False)
+                materialized.append(name)
+        return materialized
+
     @classmethod
     def _load_state_dict(
         cls,
@@ -738,6 +782,7 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
         compile_torch_model: Optional[bool] = False,
         quantize: Optional[str] = None,
         dtype: Optional[Union[str, torch.dtype]] = None,
+        low_cpu_mem_usage: bool = False,
         load_onnx_model: Optional[bool] = False,
         onnx_model_file: Optional[str] = "model.onnx",
         session_options=None,
@@ -774,6 +819,15 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
                 reading, so the full fp32 copy is never materialized — peak
                 host memory is roughly half of the default path for bf16/fp16.
                 Prefer this over ``quantize`` for plain precision changes.
+            low_cpu_mem_usage: If True, build the model under
+                ``torch.device("meta")`` and use ``load_state_dict(assign=True)``
+                to swap loaded tensors into place. Skips the random-init
+                compute, the fp32 random-init shell, and the post-init cast
+                pass — the model goes from "shape descriptor" to "loaded
+                weights" in one shot. Non-persistent buffers (e.g. DeBERTa's
+                ``position_ids``) are re-materialized after the load.
+                Default ``False`` for now (opt-in); enable for cold-start /
+                serverless deployments where every 100ms matters.
             load_onnx_model: Whether to load ONNX model instead of PyTorch.
             onnx_model_file: Path to ONNX model file.
             session_options: ONNX runtime session options.
@@ -822,25 +876,54 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
             if not model_file.exists():
                 raise FileNotFoundError(f"No model file found in {model_dir}")
 
-            # Create model instance
-            instance = cls(
-                config, tokenizer=tokenizer, backbone_from_pretrained=False, cache_dir=cache_dir, **model_kwargs
-            )
-
-            cls._resize_token_embeddings(instance, config, tokenizer, resize_token_embeddings)
-
             torch_dtype = cls._parse_dtype(dtype)
-            if torch_dtype is not None:
-                # Pre-cast the random-init shell so the model never exists at
-                # fp32 alongside the loaded state dict. ``.to(floating_dtype)``
-                # only touches floating-point params/buffers.
-                instance.model.to(torch_dtype)
 
-            # Load state dict (tensors cast to ``torch_dtype`` during read when set)
-            state_dict = cls._load_state_dict(model_file, map_location, dtype=torch_dtype)
-            instance.model.load_state_dict(state_dict, strict=strict)
-            del state_dict
-            instance.model.to(map_location)
+            if low_cpu_mem_usage:
+                # Build the model graph on meta device — no real allocation,
+                # no random-init compute. Shape descriptors only.
+                with torch.device("meta"):
+                    instance = cls(
+                        config,
+                        tokenizer=tokenizer,
+                        backbone_from_pretrained=False,
+                        cache_dir=cache_dir,
+                        **model_kwargs,
+                    )
+                cls._resize_token_embeddings(instance, config, tokenizer, resize_token_embeddings)
+
+                # Read state dict (cast on read if dtype was set), then swap
+                # tensors directly into the meta-shell parameter slots.
+                state_dict = cls._load_state_dict(model_file, map_location, dtype=torch_dtype)
+                instance.model.load_state_dict(state_dict, assign=True, strict=strict)
+                del state_dict
+
+                # Materialize non-persistent buffers (position_ids etc.) that
+                # the state dict didn't carry.
+                cls._materialize_meta_buffers(instance.model)
+
+                # If the state dict's map_location was "cpu" but the caller
+                # asked for cuda (or vice versa), move now. assign=True keeps
+                # tensors on whatever device they were loaded to.
+                instance.model.to(map_location)
+            else:
+                # Standard path: random-init shell at fp32, optional cast, load.
+                instance = cls(
+                    config,
+                    tokenizer=tokenizer,
+                    backbone_from_pretrained=False,
+                    cache_dir=cache_dir,
+                    **model_kwargs,
+                )
+                cls._resize_token_embeddings(instance, config, tokenizer, resize_token_embeddings)
+                if torch_dtype is not None:
+                    # Pre-cast the random-init shell so the model never exists at
+                    # fp32 alongside the loaded state dict. ``.to(floating_dtype)``
+                    # only touches floating-point params/buffers.
+                    instance.model.to(torch_dtype)
+                state_dict = cls._load_state_dict(model_file, map_location, dtype=torch_dtype)
+                instance.model.load_state_dict(state_dict, strict=strict)
+                del state_dict
+                instance.model.to(map_location)
 
             if compile_torch_model:
                 if "cuda" in map_location:
@@ -4192,6 +4275,7 @@ class GLiNER(nn.Module, PyTorchModelHubMixin):
         compile_torch_model: Optional[bool] = False,
         quantize: Optional[str] = None,
         dtype: Optional[Union[str, torch.dtype]] = None,
+        low_cpu_mem_usage: bool = False,
         load_onnx_model: Optional[bool] = False,
         onnx_model_file: Optional[str] = "model.onnx",
         # Config overrides
@@ -4228,6 +4312,10 @@ class GLiNER(nn.Module, PyTorchModelHubMixin):
                 are cast during the state-dict read so the fp32 copy is never
                 fully materialized; prefer this over ``quantize`` for plain
                 precision changes.
+            low_cpu_mem_usage: If True, build the model under
+                ``torch.device("meta")`` and use ``load_state_dict(assign=True)``,
+                skipping the random-init compute and the fp32 shell allocation.
+                See the base-class docstring for the full contract.
             load_onnx_model: Whether to load ONNX model instead of PyTorch.
             onnx_model_file: Path to ONNX model file.
             max_length: Override max_length in config.
@@ -4294,6 +4382,7 @@ class GLiNER(nn.Module, PyTorchModelHubMixin):
             compile_torch_model=compile_torch_model,
             quantize=quantize,
             dtype=dtype,
+            low_cpu_mem_usage=low_cpu_mem_usage,
             max_length=max_length,
             max_width=max_width,
             post_fusion_schema=post_fusion_schema,

--- a/gliner/model.py
+++ b/gliner/model.py
@@ -511,21 +511,29 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
         return cls._set_tokenizer_spec_tokens(tokenizer)
 
     @staticmethod
-    def _materialize_meta_buffers(module: nn.Module) -> list:
+    def _materialize_meta_buffers(module: nn.Module) -> tuple:
         """Re-materialize non-persistent buffers left on meta after assign-load.
 
         Walks the module tree and replaces any buffer still on the meta device
         after a meta-init + ``load_state_dict(assign=True)`` sequence.
 
-        Non-persistent buffers (registered with ``persistent=False``, e.g.
-        DeBERTa's ``position_ids``) are not in the saved state dict, so they
-        survive as meta tensors after the load. This helper restores them to
-        their canonical computed values.
+        Non-persistent buffers (registered with ``persistent=False``) are not
+        in the saved state dict, so they survive as meta tensors after the
+        load. This helper restores the ones we recognize:
 
-        Returns a list of buffer names that were materialized — useful for
-        tests and for warning on unknown patterns.
+        - ``position_ids`` — ``arange(0, max_pos).unsqueeze(0)`` (BERT/DeBERTa).
+        - ``token_type_ids`` — ``zeros((1, max_pos))`` (BERT-family default).
+
+        For *unrecognized* buffers (e.g. RoPE's ``inv_freq``, where the
+        canonical value depends on a per-architecture ``base`` we can't
+        recover from the buffer alone), this returns them in
+        ``unrecognized`` so the caller can fall back to the standard load
+        path rather than ship a model with broken inference.
+
+        Returns ``(materialized: list[str], unrecognized: list[str])``.
         """
-        materialized = []
+        materialized: list = []
+        unrecognized: list = []
         for name, buf in list(module.named_buffers()):
             if not buf.is_meta:
                 continue
@@ -538,21 +546,18 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
                 value = torch.arange(0, buf.shape[-1], dtype=buf.dtype).unsqueeze(0).contiguous()
                 parent_mod.register_buffer(leaf, value, persistent=False)
                 materialized.append(name)
-            else:
-                # Unknown non-persistent buffer — fall back to zeros and warn.
-                # If a caller hits this, the architecture has a buffer pattern
-                # we don't recognize; the user should either disable
-                # ``low_cpu_mem_usage`` or extend this method.
-                warnings.warn(
-                    f"low_cpu_mem_usage materialized unknown non-persistent buffer "
-                    f"{name!r} as zeros. Inference may be incorrect for this module. "
-                    f"Pass low_cpu_mem_usage=False to disable the meta-init path.",
-                    UserWarning,
-                    stacklevel=3,
-                )
-                parent_mod.register_buffer(leaf, torch.zeros(buf.shape, dtype=buf.dtype), persistent=False)
+            elif leaf == "token_type_ids":
+                # BERT-family default: zeros, broadcast to (1, max_pos).
+                value = torch.zeros(buf.shape, dtype=buf.dtype)
+                parent_mod.register_buffer(leaf, value, persistent=False)
                 materialized.append(name)
-        return materialized
+            else:
+                # Unrecognized non-persistent buffer. We can't safely zero-fill
+                # because the canonical value may be load-bearing (e.g. RoPE
+                # ``inv_freq`` is computed from ``base ** (arange(0, dim, 2) / dim)``
+                # and zeros would break attention). Surface to caller for fallback.
+                unrecognized.append(name)
+        return materialized, unrecognized
 
     @classmethod
     def _load_state_dict(
@@ -878,35 +883,58 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
 
             torch_dtype = cls._parse_dtype(dtype)
 
+            instance = None
             if low_cpu_mem_usage:
                 # Build the model graph on meta device — no real allocation,
                 # no random-init compute. Shape descriptors only.
                 with torch.device("meta"):
-                    instance = cls(
+                    meta_instance = cls(
                         config,
                         tokenizer=tokenizer,
                         backbone_from_pretrained=False,
                         cache_dir=cache_dir,
                         **model_kwargs,
                     )
-                cls._resize_token_embeddings(instance, config, tokenizer, resize_token_embeddings)
+                cls._resize_token_embeddings(meta_instance, config, tokenizer, resize_token_embeddings)
 
                 # Read state dict (cast on read if dtype was set), then swap
                 # tensors directly into the meta-shell parameter slots.
                 state_dict = cls._load_state_dict(model_file, map_location, dtype=torch_dtype)
-                instance.model.load_state_dict(state_dict, assign=True, strict=strict)
+                meta_instance.model.load_state_dict(state_dict, assign=True, strict=strict)
                 del state_dict
 
                 # Materialize non-persistent buffers (position_ids etc.) that
                 # the state dict didn't carry.
-                cls._materialize_meta_buffers(instance.model)
+                _materialized, unrecognized = cls._materialize_meta_buffers(meta_instance.model)
 
-                # If the state dict's map_location was "cpu" but the caller
-                # asked for cuda (or vice versa), move now. assign=True keeps
-                # tensors on whatever device they were loaded to.
-                instance.model.to(map_location)
-            else:
+                if unrecognized:
+                    # Buffers we don't know how to recompute (e.g. RoPE inv_freq
+                    # whose base varies per-architecture). The meta-init load
+                    # would produce wrong inference; fall back to the standard
+                    # path so the user gets a correct model. Cost is one full
+                    # standard load; benefit is no silent correctness bug.
+                    short_names = sorted({n.rsplit(".", 1)[-1] for n in unrecognized})
+                    warnings.warn(
+                        f"low_cpu_mem_usage=True is not supported for this architecture: "
+                        f"the model has non-persistent buffer(s) {short_names} that "
+                        f"_materialize_meta_buffers does not recognize "
+                        f"(e.g. RoPE inv_freq for ModernBERT). Falling back to the "
+                        f"standard load path so inference is correct. Pass "
+                        f"low_cpu_mem_usage=False to silence this warning.",
+                        UserWarning,
+                        stacklevel=2,
+                    )
+                    del meta_instance
+                else:
+                    # All buffers recognized — meta path succeeded.
+                    meta_instance.model.to(map_location)
+                    instance = meta_instance
+
+            if instance is None:
                 # Standard path: random-init shell at fp32, optional cast, load.
+                # Reached when low_cpu_mem_usage=False, OR when the meta-init
+                # path detected unrecognized non-persistent buffers and fell
+                # back automatically.
                 instance = cls(
                     config,
                     tokenizer=tokenizer,

--- a/tests/test_quantize_and_dtype.py
+++ b/tests/test_quantize_and_dtype.py
@@ -236,9 +236,10 @@ class TestMaterializeMetaBuffers:
         m = self._module_with_meta_position_ids(length=8)
         assert m.position_ids.is_meta  # precondition
 
-        materialized = BaseGLiNER._materialize_meta_buffers(m)
+        materialized, unrecognized = BaseGLiNER._materialize_meta_buffers(m)
 
         assert materialized == ["position_ids"]
+        assert unrecognized == []
         assert not m.position_ids.is_meta
         assert torch.equal(
             m.position_ids,
@@ -248,8 +249,9 @@ class TestMaterializeMetaBuffers:
     def test_no_op_when_no_meta_buffers(self):
         m = nn.Module()
         m.register_buffer("position_ids", torch.arange(0, 4).unsqueeze(0), persistent=False)
-        out = BaseGLiNER._materialize_meta_buffers(m)
-        assert out == []
+        materialized, unrecognized = BaseGLiNER._materialize_meta_buffers(m)
+        assert materialized == []
+        assert unrecognized == []
 
     def test_nested_module_meta_buffer_restored(self):
         """Buffers nested inside child modules are walked and fixed too."""
@@ -263,23 +265,41 @@ class TestMaterializeMetaBuffers:
         inner.position_ids = inner.position_ids.to("meta")
         outer.add_module("embeddings", inner)
 
-        materialized = BaseGLiNER._materialize_meta_buffers(outer)
+        materialized, unrecognized = BaseGLiNER._materialize_meta_buffers(outer)
 
         assert materialized == ["embeddings.position_ids"]
+        assert unrecognized == []
         assert not outer.embeddings.position_ids.is_meta
 
-    def test_unknown_meta_buffer_warns_and_zero_fills(self):
-        """Buffers we don't know how to materialize fall back to zeros + warn."""
+    def test_token_type_ids_restored_to_zeros(self):
+        """BERT-family ``token_type_ids`` is a non-persistent buffer of zeros."""
         m = nn.Module()
         m.register_buffer(
-            "mystery_constant",
-            torch.tensor([1.0, 2.0, 3.0]),
+            "token_type_ids",
+            torch.zeros((1, 6), dtype=torch.int64),
             persistent=False,
         )
-        m.mystery_constant = m.mystery_constant.to("meta")
+        m.token_type_ids = m.token_type_ids.to("meta")
 
-        with pytest.warns(UserWarning, match="unknown non-persistent buffer"):
-            materialized = BaseGLiNER._materialize_meta_buffers(m)
+        materialized, unrecognized = BaseGLiNER._materialize_meta_buffers(m)
 
-        assert materialized == ["mystery_constant"]
-        assert torch.equal(m.mystery_constant, torch.zeros(3))
+        assert materialized == ["token_type_ids"]
+        assert unrecognized == []
+        assert torch.equal(m.token_type_ids, torch.zeros((1, 6), dtype=torch.int64))
+
+    def test_unknown_buffer_returned_as_unrecognized(self):
+        """Unrecognized buffers are surfaced for caller-side fallback (not zero-filled)."""
+        m = nn.Module()
+        m.register_buffer(
+            "inv_freq",
+            torch.tensor([1.0, 0.5, 0.25]),
+            persistent=False,
+        )
+        m.inv_freq = m.inv_freq.to("meta")
+
+        materialized, unrecognized = BaseGLiNER._materialize_meta_buffers(m)
+
+        assert materialized == []
+        assert unrecognized == ["inv_freq"]
+        # The buffer is still meta — caller must fall back to the standard load path.
+        assert m.inv_freq.is_meta

--- a/tests/test_quantize_and_dtype.py
+++ b/tests/test_quantize_and_dtype.py
@@ -303,3 +303,58 @@ class TestMaterializeMetaBuffers:
         assert unrecognized == ["inv_freq"]
         # The buffer is still meta — caller must fall back to the standard load path.
         assert m.inv_freq.is_meta
+
+
+class TestMetaParamFallbackContract:
+    """Codex review finding: with ``low_cpu_mem_usage=True`` and the default
+    ``strict=False``, ``load_state_dict(assign=True)`` may leave a parameter
+    on the meta device when the checkpoint is missing a key. The subsequent
+    ``.to(map_location)`` then raises ``NotImplementedError: Cannot copy out
+    of meta tensor``, whereas the standard path would have kept the
+    random-init value and loaded successfully.
+
+    These tests assert the *contract* underlying the fix without spinning up
+    a real GLiNER model: ``load_state_dict(assign=True, strict=False)`` does
+    leave parameters on meta when keys are missing, and the
+    "scan for meta parameters after assign" check in ``from_pretrained``
+    correctly identifies them.
+    """
+
+    def test_assign_load_with_missing_key_leaves_param_on_meta(self):
+        """The premise — without our scan, ``.to()`` would crash."""
+        with torch.device("meta"):
+            module = nn.Linear(4, 4)
+        # State dict is missing the bias.
+        partial_sd = {"weight": torch.randn(4, 4)}
+        result = module.load_state_dict(partial_sd, assign=True, strict=False)
+        assert "bias" in result.missing_keys
+        # The bug: bias is still on meta.
+        assert module.bias.is_meta
+        # And .to() on a meta param raises.
+        with pytest.raises(NotImplementedError, match="meta"):
+            module.to("cpu")
+
+    def test_meta_param_scan_finds_missing_assign_targets(self):
+        """The fix's scan: walk named_parameters looking for ``is_meta``,
+        report names so the fallback warning can surface them."""
+        with torch.device("meta"):
+            module = nn.Sequential(nn.Linear(4, 4), nn.Linear(4, 2))
+        # Provide weights but not biases.
+        partial_sd = {
+            "0.weight": torch.randn(4, 4),
+            "1.weight": torch.randn(2, 4),
+        }
+        module.load_state_dict(partial_sd, assign=True, strict=False)
+        meta_params = [n for n, p in module.named_parameters() if p.is_meta]
+        assert sorted(meta_params) == ["0.bias", "1.bias"]
+
+    def test_full_assign_load_leaves_no_meta_params(self):
+        """Sanity: when the state dict is complete, no meta params remain."""
+        with torch.device("meta"):
+            module = nn.Linear(4, 4)
+        full_sd = {"weight": torch.randn(4, 4), "bias": torch.randn(4)}
+        module.load_state_dict(full_sd, assign=True, strict=False)
+        meta_params = [n for n, p in module.named_parameters() if p.is_meta]
+        assert meta_params == []
+        # And .to() succeeds on the materialized module.
+        module.to("cpu")

--- a/tests/test_quantize_and_dtype.py
+++ b/tests/test_quantize_and_dtype.py
@@ -214,3 +214,72 @@ class TestFromPretrainedQuantizeTrueRejection:
         # ``_FakeModel("cpu").quantize(True)`` which also raises.
         with pytest.raises(TypeError, match="expects a string"):
             _FakeModel("cpu").quantize(True)
+
+
+class TestMaterializeMetaBuffers:
+    """``_materialize_meta_buffers`` post-fixes non-persistent buffers that
+    survive a meta-init + ``load_state_dict(assign=True)`` cycle."""
+
+    def _module_with_meta_position_ids(self, length: int = 16) -> nn.Module:
+        """Build a small module mirroring DeBERTa's ``position_ids`` buffer
+        registration, then move it to meta to simulate post-load state."""
+        module = nn.Module()
+        module.register_buffer(
+            "position_ids",
+            torch.arange(0, length, dtype=torch.int64).unsqueeze(0),
+            persistent=False,
+        )
+        module.position_ids = module.position_ids.to("meta")
+        return module
+
+    def test_position_ids_restored_to_canonical_value(self):
+        m = self._module_with_meta_position_ids(length=8)
+        assert m.position_ids.is_meta  # precondition
+
+        materialized = BaseGLiNER._materialize_meta_buffers(m)
+
+        assert materialized == ["position_ids"]
+        assert not m.position_ids.is_meta
+        assert torch.equal(
+            m.position_ids,
+            torch.arange(0, 8, dtype=torch.int64).unsqueeze(0),
+        )
+
+    def test_no_op_when_no_meta_buffers(self):
+        m = nn.Module()
+        m.register_buffer("position_ids", torch.arange(0, 4).unsqueeze(0), persistent=False)
+        out = BaseGLiNER._materialize_meta_buffers(m)
+        assert out == []
+
+    def test_nested_module_meta_buffer_restored(self):
+        """Buffers nested inside child modules are walked and fixed too."""
+        outer = nn.Module()
+        inner = nn.Module()
+        inner.register_buffer(
+            "position_ids",
+            torch.arange(0, 4, dtype=torch.int64).unsqueeze(0),
+            persistent=False,
+        )
+        inner.position_ids = inner.position_ids.to("meta")
+        outer.add_module("embeddings", inner)
+
+        materialized = BaseGLiNER._materialize_meta_buffers(outer)
+
+        assert materialized == ["embeddings.position_ids"]
+        assert not outer.embeddings.position_ids.is_meta
+
+    def test_unknown_meta_buffer_warns_and_zero_fills(self):
+        """Buffers we don't know how to materialize fall back to zeros + warn."""
+        m = nn.Module()
+        m.register_buffer(
+            "mystery_constant",
+            torch.tensor([1.0, 2.0, 3.0]),
+            persistent=False,
+        )
+        m.mystery_constant = m.mystery_constant.to("meta")
+
+        with pytest.warns(UserWarning, match="unknown non-persistent buffer"):
+            materialized = BaseGLiNER._materialize_meta_buffers(m)
+
+        assert materialized == ["mystery_constant"]
+        assert torch.equal(m.mystery_constant, torch.zeros(3))


### PR DESCRIPTION
# Add `low_cpu_mem_usage=True` to `from_pretrained` for ~2× faster cold starts

## Why

Cold-start latency in `from_pretrained` has three layers:

1. **Bytes-on-the-wire** — the `variant=` PR ([#354](https://github.com/urchade/GLiNER/pull/354)) addresses this: when the publisher has uploaded a half-precision file, the download shrinks by ~half (745 MB → 372 MB for `gliner_medium-v2.1`).
2. **CPU-side model construction and init** — this PR addresses this. Regardless of how many bytes you downloaded, `from_pretrained` still:
   - Allocates a ~745 MB fp32 random-initialized model shell.
   - Runs Kaiming / Xavier initialization over every parameter.
   - Casts the entire shell to bf16 (when `dtype=` is set).
   - Overwrites every value with the loaded weights.
   Steps 1–3 are all thrown away. The randoms are never used. The cast operates on data that's about to be overwritten.
3. **GPU transfer + first-inference JIT** — out of scope for both PRs.

The two lower-layer changes are orthogonal and stack. `variant=` shrinks the download; `low_cpu_mem_usage=True` shrinks the per-load CPU work that fires regardless of what the publisher uploaded.

## What this PR adds

A new opt-in `low_cpu_mem_usage: bool = False` flag on both `BaseGLiNER.from_pretrained` and the outer `GLiNER.from_pretrained` dispatcher:

```python
model = GLiNER.from_pretrained(
    "urchade/gliner_medium-v2.1",
    dtype="bf16",
    low_cpu_mem_usage=True,
)
```

When `True`:

1. Build the model graph under `torch.device("meta")` — shape descriptors only, no allocation, no init compute.
2. Read the state dict at the target precision (the existing `dtype=` cast-on-read path).
3. `load_state_dict(state_dict, assign=True)` swaps the loaded tensors directly into the meta-shell parameter slots in one pass.
4. Re-materialize non-persistent buffers (`position_ids`, `token_type_ids`) the state dict didn't carry.
5. **Auto-fall-back to the standard load path** when the model has non-persistent buffers we don't know how to recompute (e.g. RoPE's `inv_freq`, whose `base` varies per-architecture). The fallback emits a single `UserWarning` naming the unsupported buffer and produces a bit-identical model via the standard load path.
6. Move to `map_location`.

The auto-fallback is the key design choice: rather than ship silently-broken inference for architectures we haven't validated, we detect the unsupported case and quietly use the slow path. Users get the speedup where it's safe and a working model where it isn't, with the warning telling them which case they hit.

## Benchmark results

`urchade/gliner_medium-v2.1`, RTX 5090, n=12 reps per mode, OS page cache warmed (2 discarded warmups), Welch t-tested. Each load runs in a fresh subprocess so peak memory isn't contaminated by prior allocations. Modes interleave within each rep block to defuse warm-cache bias.

### Wall-clock load time

| pairing | baseline | `low_cpu_mem_usage=True` | speedup | saved | Welch t |
|---|---|---|---|---|---|
| CPU bf16 | 3.30 s | **1.60 s** | **2.06×** | 1700 ms | +14.67 |
| CPU fp32 | 3.04 s | **1.45 s** | **2.10×** | 1591 ms | +12.81 |
| CUDA bf16 | 3.16 s | **1.61 s** | **1.96×** | 1543 ms | +20.96 |

All effect sizes are |t| > 12 — far above the noise floor. **~1.5 s saved on every cold start, regardless of dtype or device.** Stdev also drops ~3× (0.38 s → 0.12 s for CPU bf16) because there's much less work happening in the load path.

### Peak host RSS

| pairing | baseline | `low_cpu_mem_usage=True` | reduction |
|---|---|---|---|
| CPU bf16 | 1597 MB | 1225 MB | −23% |
| CPU fp32 | 1598 MB | 170 MB | **−89%** |
| CUDA bf16 | 1361 MB | 1004 MB | −26% |

The CPU fp32 case is dramatic because safetensors mmaps the on-disk file and the loaded tensors are views into the mmap — we never copy the model into anonymous memory at all.

GPU peak unchanged at 585 MB (the `dtype=` work in PR #348 already covered that).

Raw data: `benchmarks/low_cpu_mem_usage/results.json`. Driver: `benchmarks/low_cpu_mem_usage/run_bench.py`.

## Architecture validation

Validated across every cached GLiNER architecture I had locally — script at `benchmarks/low_cpu_mem_usage/arch_validation.py`. Each model loads twice (baseline vs. `low_cpu_mem_usage=True`), the parameters are SHA-256 hashed end-to-end, and predictions are compared on a held-out sentence:

| model | dispatcher class | result | path taken |
|---|---|---|---|
| `urchade/gliner_small-v2.1` | `UniEncoderSpanGLiNER` | params identical, preds match | meta-init |
| `urchade/gliner_large-v2.1` | `UniEncoderSpanGLiNER` | params identical, preds match | meta-init |
| `gliner-community/gliner_small-v2.5` | `UniEncoderSpanGLiNER` | params identical, preds match | meta-init |
| `knowledgator/gliner-multitask-large-v0.5` | `UniEncoderTokenGLiNER` | params identical, preds match | meta-init |
| `knowledgator/gliner-bi-base-v2.0` | `BiEncoderSpanGLiNER` | params identical (preds skipped — pre-existing forward bug) | **auto-fallback** (`inv_freq` from ettin RoPE) |
| `knowledgator/modern-gliner-bi-base-v1.0` | `BiEncoderSpanGLiNER` | params identical (preds skipped — pre-existing forward bug) | **auto-fallback** (`inv_freq` from ModernBERT RoPE) |

**4 of 6 models take the fast meta-init path. 2 of 6 auto-fall-back due to RoPE.** Both groups produce bit-identical loaded parameters to the standard load. The two skipped predictions are because of an upstream bug in the bi-encoder forward path (`BertModel.forward() got an unexpected keyword argument 'token_lengths'`) that fails on the baseline too — unrelated to this PR.

The bi-encoder inference fail is a pre-existing GLiNER bug on these specific bi-encoder repos; the load itself works correctly.

### Architectures not validated

I didn't have cached checkpoints for these dispatcher classes:

- `BiEncoderTokenGLiNER`
- `UniEncoderSpanDecoderGLiNER` / `UniEncoderTokenDecoderGLiNER`
- `UniEncoderSpanRelexGLiNER` / `UniEncoderTokenRelexGLiNER`

If any of them register non-persistent buffers we don't recognize, they'll auto-fall-back to the standard path with a warning naming the unsupported buffer. They will not silently produce wrong inference. Worth running the validation script against representative checkpoints once they're available.

## Correctness verification

- **Bit-identical parameters** verified via SHA-256 hash across all 6 validated architectures.
- **0 missing keys, 0 unexpected keys** in `load_state_dict(assign=True)` on the DeBERTa path.
- **0 leftover meta tensors** on the meta path; auto-fallback engages cleanly when unrecognized buffers exist.
- **End-to-end inference matches** on the four DeBERTa-based models; bi-encoder inference skipped due to upstream forward bug (independent of this PR).
- **CUDA path verified** — `map_location="cuda"` produces a model with all parameters on `cuda:0` at the requested dtype.

## No regressions

- **200 existing unit tests pass**, 1 pre-existing skip (unrelated), 1 pre-existing import error in `tests/test_infer_packing.py` (`ModuleNotFoundError: No module named 'tests.utils_infer'` — broken before this PR).
- **5 new unit tests** for `_materialize_meta_buffers`: position_ids round-trip, no-op when nothing on meta, nested-module recursion, token_type_ids round-trip, unknown-buffer returns as `unrecognized` (so the caller can fall back).
- `ruff check` and `ruff format --check` clean.

## Files changed

- **`gliner/model.py`** — `_materialize_meta_buffers` static helper returning `(materialized, unrecognized)`. `low_cpu_mem_usage: bool = False` argument added to both `from_pretrained` entry points. The inner `from_pretrained` branches between standard path and meta-init; on unrecognized buffers, the meta state is discarded and the standard path runs as a fallback. Standard path remains byte-for-byte unchanged.
- **`tests/test_quantize_and_dtype.py`** — new `TestMaterializeMetaBuffers` class with 5 cases. 55 total tests passing.
- **`docs/usage.md`** — new "Skipping the random-init shell (`low_cpu_mem_usage`)" subsection with the benchmark table.

## What this stacks with

| optimization | what it does | typical savings on `gliner_medium-v2.1` |
|---|---|---|
| `dtype="bf16"` (already merged) | cast-on-read; no fp32 state dict in memory | ~37% GPU peak; **0% wall-clock** |
| `variant="bf16"` (PR #354) | download only the bf16 file from Hub | ~373 MB bytes-on-wire (when published) |
| `low_cpu_mem_usage=True` (this PR) | skip random-init compute + fp32 alloc + cast pass | **~50% wall-clock**, 23–89% peak host RSS |

Used together, the cold-start path on `gliner_medium-v2.1` against a publisher who has uploaded a bf16 variant goes from "download 745 MB, build fp32 shell, init, cast, load" (~3 s + download) to "download 372 MB, build meta shell, load directly into bf16" (~1.5 s + half the download).

## Why opt-in (default `False`)

Real downsides — none dealbreakers, all reasons to ship cautiously:

1. **Architecture coverage.** I validated 3 of 8 dispatcher classes. The other 5 (BiEncoderToken, the two decoder variants, the two relex variants) should work or auto-fall-back, but haven't been load-tested.
2. **`load_state_dict(assign=True)` requires PyTorch 2.1+.** Default-on would break users pinned to older torch.
3. **Tied weights would break silently.** `assign=True` replaces parameters with new tensors; if a model ties input embeddings to output projections (RoBERTa-style), the tie breaks. DeBERTa-v3 doesn't tie, so current GLiNER models are safe — but a future fine-tune on a tied-weight backbone would silently degrade.
4. **User subclasses.** Anyone subclassing `BaseGLiNER` for a custom architecture would see their `_create_model` run under `torch.device("meta")` if the default flips. Subtle bugs in custom code wouldn't be caught.
5. **Diagnostic blast radius.** Bugs here are wrong-but-plausible outputs rather than crashes. Opt-in is self-documenting in user configs; default-on means "I upgraded GLiNER and predictions changed slightly" is harder to trace.

Recommended rollout: ship as opt-in, validate the remaining 5 architectures against representative checkpoints, then flip the default. The auto-fallback design means flipping the default is a smaller risk than it would be otherwise — anything we missed produces a fallback warning, not a wrong model.

## Followups

- **Validate the remaining 5 dispatcher classes** (BiEncoderToken, two decoder variants, two relex variants) against representative checkpoints.
- **Test on a tied-weights architecture.** Add coverage for any future GLiNER backbone that ties embeddings to output projections.
- **Architectures with non-position_ids / non-token_type_ids / non-inv_freq buffers.** The fallback handles unknowns safely, but extending `_materialize_meta_buffers` to recognize them turns auto-fallback into full speedup. A small contribution from anyone hitting the warning.
- **`gliner.serve` CLI flag.** The serving layer is the canonical cold-start use case; adding `--low-cpu-mem-usage` to `gliner.serve.__main__` is the obvious follow-up. Deliberately scoped out of this PR.
