### PR TITLE
Add github workflow for automatic PyPI releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,70 @@
+name: Release GLiNER to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*'  # Trigger on version tags (e.g., v1.0.0, v2.1.3)
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build distribution 📦
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.x"
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v5
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-pypi:
+    name: >-
+      Publish Python 🐍 distribution 📦 to PyPI
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/<package-name>  # Replace <package-name> with your PyPI project name
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0  # Fetch all history to check branches
+    - name: Verify tag is on main branch
+      run: |
+        if ! git branch -r --contains ${{ github.ref_name }} | grep -q 'origin/main'; then
+          echo "Error: Tag ${{ github.ref_name }} is not on the main branch"
+          exit 1
+        fi
+        echo "✓ Tag ${{ github.ref_name }} is on main branch"
+    - name: Download all the dists
+      uses: actions/download-artifact@v6
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -22,6 +22,81 @@ The very first release should be "0.1.0".
 
 ## Releases
 
+GLiNER supports two release methods: **automated releases via GitHub Actions** (recommended) and manual releases via `twine`. The automated method is preferred as it ensures consistency and uses PyPI's trusted publishing.
+
+### Automated Release via GitHub Actions (Recommended)
+
+The repository includes a GitHub Actions workflow (`.github/workflows/release.yaml`) that automatically builds and publishes releases to PyPI when you push a version tag to the main branch.
+
+#### Prerequisites
+
+1. Ensure PyPI trusted publishing is configured for the GLiNER project in your PyPI account settings
+2. The GitHub Actions workflow must have the proper PyPI environment configured
+
+#### Steps for Automated Release
+
+**Step 1: Adjust the version of your package**
+
+Update the version in [`gliner/__init__.py`](gliner/__init__.py) from dev to release version:
+
+```diff
+- __version__ = "0.4.0.dev"
++ __version__ = "0.4.0"
+```
+
+Commit and push to main:
+
+```bash
+git add gliner
+git commit -m "Release: v{VERSION}"
+git push origin main
+```
+
+**Step 2: Create and push a version tag**
+
+Create a tag matching the pattern `v*` (e.g., `v0.4.0`) and push it to trigger the release:
+
+```bash
+git tag v<VERSION>
+git push origin v<VERSION>
+```
+
+**Important:** The tag MUST be pushed to the main branch. The workflow will automatically verify this and fail if the tag is from any other branch.
+
+**Step 3: Monitor the GitHub Actions workflow**
+
+1. Go to [https://github.com/urchade/GLiNER/actions](https://github.com/urchade/GLiNER/actions)
+2. Watch the "Release GLiNER to PyPI" workflow execution
+3. The workflow will:
+   - Build the distribution packages (wheel and source tarball)
+   - Verify the tag is on the main branch
+   - Publish to PyPI using trusted publishing
+
+**Step 4: (Optional) Prepare release notes**
+
+Create release notes on GitHub at [https://github.com/urchade/GLiNER/releases](https://github.com/urchade/GLiNER/releases) using the tag you just created.
+
+**Step 5: Bump the dev version**
+
+After a successful release, update [`gliner/__init__.py`](gliner/__init__.py) to the next dev version:
+
+```diff
+- __version__ = "0.4.0"
++ __version__ = "0.4.1.dev"
+```
+
+Commit and push:
+
+```bash
+git add gliner
+git commit -m "Bump version to {NEXT_VERSION}.dev"
+git push origin main
+```
+
+### Manual Release via twine
+
+If you need to release manually or the automated workflow is unavailable, follow these steps:
+
 ### Step 1: Adjust the version of your package
 
 You should have the current version specified in [`gliner/__init__.py`](gliner/__init__.py). This version should be a dev version (e.g. `0.1.0.dev`) before you release, change it to the name of the version you are releasing:
@@ -154,3 +229,5 @@ Go back to the draft you did at step 4 ([https://github.com/urchade/GLiNER/relea
 ### Step 9: Bump the dev version on the main branch
 
 You’re almost done! Just go back to the `main` branch and change the dev version in [`gliner/__init__.py`](gliner/__init__.py) to the new version you’re developing, for instance `4.13.0.dev` if just released `4.12.0`.
+
+**Note:** This step applies to both the automated and manual release processes.


### PR DESCRIPTION
# Add Automated PyPI Release Workflow

## Summary
Adds GitHub Actions workflow to automate PyPI releases when version tags are pushed to the main branch.

## What it does
- Triggers on version tags (e.g., `v1.0.0`, `v2.1.3`)
- Builds distribution packages (wheel + source)
- Verifies tag is on `main` branch before publishing
- Publishes to PyPI using trusted publishing

## Required actions

### 1. Configure PyPI Trusted Publishing (Required before first release)

**What is Trusted Publishing?**
Trusted Publishing allows GitHub Actions to publish to PyPI without using API tokens or passwords. It uses OpenID Connect (OIDC) for secure authentication directly from GitHub.

**Benefits:**
- No API tokens to manage or rotate
- More secure (no credentials in secrets)
- Recommended by PyPI as best practice

**Setup Steps:**

1. **Log in to PyPI** at https://pypi.org (you must be a maintainer/owner of the `gliner` package)

2. **Navigate to Publishing Settings**:
   - Go to https://pypi.org/manage/project/gliner/settings/publishing/
   - Or: Your projects → `gliner` → Settings → Publishing

3. **Add a new pending publisher** with these values:
   - **PyPI Project Name**: `gliner`
   - **Owner**: `urchade` (or your GitHub org/username)
   - **Repository name**: `GLiNER`
   - **Workflow name**: `release.yaml`
   - **Environment name**: `pypi`

4. **Save** - The publisher will be in "pending" state until the first successful workflow run

**Official Documentation:**
- PyPI Trusted Publishing Guide: https://docs.pypi.org/trusted-publishers/
- GitHub OIDC Publishing: https://docs.pypi.org/trusted-publishers/adding-a-publisher/
- PyPI Security Best Practices: https://pypi.org/help/#publishing

**Note:** If trusted publishing is not configured, the workflow will fail at the publish step with an authentication error.

### 2. To trigger a release
Push a version tag to main: 
```bash
git tag v0.4.0 && git push origin v0.4.0
```

### 3. Documentation updated
`RELEASE.md` now includes automated release instructions

## Safety
- Only tags from `main` branch will be published
- Failed branch verification prevents accidental releases from feature branches
