### PR TITLE
Fix token_lengths kwarg leaking into the labels encoder

### DIFF
--- a/gliner/modeling/encoder.py
+++ b/gliner/modeling/encoder.py
@@ -943,8 +943,8 @@ class BiEncoder(Encoder):
             input_ids: Label token IDs of shape (batch_size, seq_len).
             attention_mask: Attention mask of shape (batch_size, seq_len).
             *args: Additional positional arguments.
-            **kwargs: Additional keyword arguments (packing_config and pair_attention_mask
-                are removed as they're not supported for labels).
+            **kwargs: Additional keyword arguments (packing_config, pair_attention_mask
+                and token_lengths are removed as they're not supported for labels).
 
         Returns:
             Pooled label embeddings of shape (batch_size, hidden_size).
@@ -952,6 +952,11 @@ class BiEncoder(Encoder):
         label_kwargs = dict(kwargs)
         label_kwargs.pop("packing_config", None)
         label_kwargs.pop("pair_attention_mask", None)
+        # token_lengths carries precomputed lengths for the *text* inputs (see
+        # collator); forwarding it to the labels encoder crashes plain HF
+        # backbones ("BertModel.forward() got an unexpected keyword argument
+        # 'token_lengths'", #370).
+        label_kwargs.pop("token_lengths", None)
         label_kwargs["attention_mask"] = attention_mask
         labels_embeddings = self.labels_encoder(input_ids, *args, **label_kwargs)
         if hasattr(self, "labels_projection"):


### PR DESCRIPTION
Fixes #370

## Problem

Since 3a38d45 ("make gliner serving more efficient") the collator emits a `token_lengths` kwarg — precomputed CPU-side text lengths that avoid an `attention_mask.sum().tolist()` GPU→CPU sync. The uni-encoder text path pops it, but `BiEncoder.encode_labels` only removed `packing_config` and `pair_attention_mask` before forwarding kwargs to the labels backbone. The text-side `token_lengths` therefore reaches the labels encoder and crashes any plain HF backbone:

```
TypeError: BertModel.forward() got an unexpected keyword argument 'token_lengths'
```

This breaks every bi-encoder checkpoint (e.g. `knowledgator/modern-gliner-bi-base-v1.0`, `knowledgator/modern-gliner-bi-large-v1.0`) on transformers 4.x. Bisected to 3a38d45: every commit before it predicts correctly, every commit after crashes.

## Fix

Pop `token_lengths` in `encode_labels` alongside the other text-side kwargs — the value describes text sequences and is meaningless for label sequences.

## Verification

`knowledgator/modern-gliner-bi-base-v1.0` + transformers 4.48.3:

- current main: `TypeError` above
- with this fix: `[('Angela Merkel', 'person', 0.85), ('Kyiv', 'location', 0.75), ('CDU', 'organization', 0.93)]` — identical to gliner 0.2.16 output

Note: on transformers 5.x this crash does not reproduce (the kwarg is silently swallowed), but bi-encoders fail there for an unrelated reason — see the companion PR for #324.