### PR TITLE
Fix UniEncoderSpanRelexGLiNER.evaluate

### DIFF
--- a/gliner/evaluation/evaluator.py
+++ b/gliner/evaluation/evaluator.py
@@ -251,7 +251,22 @@ class BaseRelexEvaluator(BaseEvaluator):
             t = rel[2]
             h_ent = ents[h]
             t_ent = ents[t]
-            all_rels.append([lab, (h_ent[0], h_ent[1], t_ent[0], t_ent[1])])
+
+            if isinstance(h_ent, Span):
+                h_ent_start = h_ent.start
+                h_ent_end = h_ent.end
+            else:
+                h_ent_start = h_ent[0]
+                h_ent_end = h_ent[1]
+            if isinstance(t_ent, Span):
+                t_ent_start = t_ent.start
+                t_ent_end = t_ent.end
+            else:
+                t_ent_start = t_ent[0]
+                t_ent_end = t_ent[1]
+            
+            all_rels.append([lab, (h_ent_start, h_ent_end, t_ent_start, t_ent_end)])
+            
         return all_rels
 
     def transform_data(self):

--- a/gliner/evaluation/evaluator.py
+++ b/gliner/evaluation/evaluator.py
@@ -4,6 +4,7 @@ import numpy as np
 import torch
 
 from .utils import _prf_divide, flatten_for_eval, extract_tp_actual_correct
+from ..decoding.decoder import Span
 
 
 class BaseEvaluator(ABC):

--- a/gliner/model.py
+++ b/gliner/model.py
@@ -5713,6 +5713,7 @@ class UniEncoderSpanRelexGLiNER(BaseEncoderGLiNER):
         relation_threshold: Optional[float] = None,
         batch_size: int = 12,
         entity_types: Optional[List[str]] = None,
+        relation_types: Optional[List[str]] = None,
     ) -> Tuple[Tuple[Any, float], Tuple[Any, float]]:
         """Evaluate the model on both NER and relation extraction tasks.
 
@@ -5725,6 +5726,7 @@ class UniEncoderSpanRelexGLiNER(BaseEncoderGLiNER):
             relation_threshold: The threshold for relation predictions. Defaults to threshold.
             batch_size: The batch size for evaluation. Defaults to 12.
             entity_types: Optional list of entity types to evaluate. If None, extracts from test data. Defaults to None.
+            relation_types: Optional list of relation types to evaluate. If None, extracts from test data. Defaults to None.
 
         Returns:
             Tuple of ((ner_output, ner_f1), (rel_output, rel_f1)) containing:
@@ -5755,7 +5757,7 @@ class UniEncoderSpanRelexGLiNER(BaseEncoderGLiNER):
         )
 
         def collate_fn(batch):
-            return collator(batch, entity_types=entity_types)
+            return collator(batch, entity_types=entity_types, relation_types=relation_types)
 
         data_loader = torch.utils.data.DataLoader(dataset, batch_size=batch_size, shuffle=False, collate_fn=collate_fn)
 


### PR DESCRIPTION
Hey, first of all thank you for this great repo. This is my first pull request, so maybe I will make mistakes here.

### 1. Error
The function `UniEncoderSpanRelexGLiNER.evaluate(...)` does not take relation_types as input, so that the model never produces any relations, when entity_types are given, and the eval of the relations is therefore 0. 

Solution: `UniEncoderSpanRelexGLiNER.evaluate(...)` now takes relation_types in the same manner as it takes entity_types and these are also given to the collator in the `collate_fn(...)` function. 

### 2. Error
After correcting the first Error one gets a second error, because `BaseRelexEvaluator.get_predictions(...)` is given entity Spans instead of entity tuples and can't handle them. 

Solution: Handle entities based on if Span or tuple type.

Additionally here is a short script, that should run without errors and zeros in the output, when the fixes are implemented:
```
from gliner.model import GLiNER

model = GLiNER.from_pretrained(
    "knowledgator/gliner-relex-large-v1.0"
)

train_data = [
    {
        "tokenized_text": ["John", "Smith", "works", "at", "Microsoft", "in", "Seattle"],
        "ner": [
            [0, 1, "person"],
            [4, 4, "organization"],
            [6, 6, "location"]
        ],
        # Relations: [head_entity_idx, tail_entity_idx, relation_type]
        "relations": [
            [0, 1, "works_at"],      # person 0 works_at organization 1
            [1, 2, "located_in"]     # organization 1 located_in location 2
        ],
        # Optional: explicit relation types

    }
]
rel_labels = ["works_at", "located_in", "founded_by"]
ent_labels = ["person", "organization", "location"]

# Reproduce Error 1 run
output = model.evaluate(
    train_data, flat_ner=True, threshold=0.5, batch_size=1, entity_types=ent_labels, relation_types=rel_labels
)

# Reproduce Error 2 run
# output = model.evaluate(
#     train_data, flat_ner=True, threshold=0.5, batch_size=1
# )

print(output)
```
## Additional Question:
If the entity_types are not given they are extracted from test data, regardless of relation_types given or not.
But relation_types if not given are only extracted from test data if entity_types are also not given.
Thats why currently
```
output = model.evaluate(
    train_data, flat_ner=True, threshold=0.5, batch_size=1, entity_types=ent_labels
)
```
produces no relations.
I looked at `RelationExtractionSpanProcessor.collate_raw_batch(...)` but dont know if it is supposed to be like that?
