### PR TITLE
Add ability to provide labels descriptions

### DIFF
--- a/docs/serving.md
+++ b/docs/serving.md
@@ -67,6 +67,21 @@ outputs = client.predict(
 )  # → list[dict], one per input text
 ```
 
+Label descriptions and per-text label sets use the same API as local inference:
+
+```python
+outputs = client.predict(
+    ["John works at Google", "Paris is in France"],
+    labels=[
+        {"person": "A human individual", "organization": "A company or institution"},
+        {"location": "A geographical place"},
+    ],
+)
+```
+
+Each dictionary key is returned as the entity label; its value is the prompt encoded
+for that text. A single dictionary is shared across every input text.
+
 Network or server errors surface as `gliner.serve.client.GLiNERClientError`.
 
 :::{warning}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -113,6 +113,32 @@ for i, entities in enumerate(all_entities):
 - **Efficient**: Better GPU utilization
 - **Scalable**: Handle large document collections
 
+### Label descriptions
+
+Models trained to use descriptive labels can receive a dictionary. Dictionary keys are
+returned in predictions, while values are encoded as the label prompts:
+
+```python
+labels = {
+    "person": "A human individual, including fictional characters",
+    "organization": "A company, institution, agency, or other group of people",
+}
+entities = model.predict_entities(text, labels)
+```
+
+For batched inference, provide one dictionary or list of labels per text:
+
+```python
+label_sets = [
+    {"person": "A human individual"},
+    {"location": "A geographical place"},
+]
+entities = model.inference(["Alice arrived", "Paris is sunny"], label_sets)
+```
+
+Descriptions must be unique within each label set. They are not supported with
+precomputed prompt embeddings.
+
 ## Using Different Model Architectures
 
 GLiNER supports multiple architecture variants, each optimized for different scenarios.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -69,6 +69,69 @@ for entity in entities:
     print("---")
 ```
 
+### Returning contextual vectors
+
+Native PyTorch models can return the contextual representation of every
+accepted entity together with the representation of its matched label. The two
+options are independent and are disabled by default:
+
+```python
+entities = model.predict_entities(
+    text,
+    labels,
+    return_vectors=True,
+    return_label_vectors=True,
+)
+
+for entity in entities:
+    span_vector = entity["vector"]
+    label_vector = entity["label_vector"]
+```
+
+`inference` supports the same options for batched input:
+
+```python
+all_entities = model.inference(
+    texts,
+    labels,
+    batch_size=8,
+    return_vectors=True,
+    return_label_vectors=True,
+)
+```
+
+The optional values are detached CPU NumPy arrays with `float32` dtype. Their
+meaning depends on the model architecture:
+
+- For a span-level model, `vector` is the native contextual span
+  representation used by the span scorer.
+- For a token-level model, `vector` is the mean of the contextual word
+  representations covered by the detected span.
+- `label_vector` is the matched model prompt representation. When labels are
+  supplied as a label-to-description mapping, this is the representation of
+  the description prompt while `entity["label"]` remains the mapping key.
+  For a generative model in prompt mode, it still represents the original
+  scoring prompt; generated label text is not encoded a second time.
+
+The mean-pooled token-level `vector` is not guaranteed to reproduce the entity
+score when combined with `label_vector`; in particular, standard token-level
+decoding uses the nonlinear start/end/inside scorer. Both arrays are intended
+as contextual features for a downstream model.
+Only entities that survive thresholding and overlap filtering receive vectors.
+When the flags are `False`, the corresponding keys are absent, preserving the
+standard result format and inference cost.
+
+NumPy arrays are not directly JSON serializable. Convert them with `.tolist()`
+when a JSON-compatible response is required.
+
+:::{note}
+Vector returns currently require native PyTorch inference. Existing ONNX and
+OpenVINO exports do not expose these intermediate representations and raise
+`NotImplementedError` when either option is requested. Stateless inference with
+a streaming-span model is supported, but stateful streaming sessions do not
+currently return vectors.
+:::
+
 :::{warning}
 Stateless GLiNER calls do not automatically window long documents. If the text
 contains more splitter tokens than the checkpoint's `model.config.max_len`,
@@ -277,6 +340,49 @@ Relations:
   Microsoft --[headquartered_in]--> Redmond
 ```
 </details>
+
+### Returning relation vectors
+
+Relation extraction returns entity and relation representations through the
+same options. They are available from both batched `inference` and the
+single-text `predict_relations` convenience method:
+
+```python
+all_entities, all_relations = model.inference(
+    [text],
+    labels=entity_labels,
+    relations=relation_labels,
+    return_vectors=True,
+    return_label_vectors=True,
+)
+
+entities, relations = model.predict_relations(
+    text,
+    labels=entity_labels,
+    relations=relation_labels,
+    return_vectors=True,
+    return_label_vectors=True,
+)
+```
+
+The returned entity dictionaries use `vector` and `label_vector` as described
+above. A relation dictionary always keeps its normal `head`, `tail`,
+`relation`, and `score` fields, and adds the requested arrays according to its
+relation scorer:
+
+| Relation scorer | Fields added by `return_vectors=True` |
+| --- | --- |
+| Pair projection | `vector`, the projected directed head-tail pair representation |
+| Triple scorer | `head_relation_vector` and `tail_relation_vector`, the two entity-side scorer inputs |
+
+With `return_label_vectors=True`, both scorer types also add `label_vector`,
+the matched relation-prompt representation. All relation vectors are detached
+CPU `float32` NumPy arrays. For a pair projection, `vector` is the
+representation directly compared with `label_vector`; a triple scorer has no
+single pair vector, which is why its two exact entity-side inputs are returned
+instead. The `head` and `tail` sub-dictionaries are unchanged; use their
+`entity_idx` values to locate the corresponding entity dictionaries and entity
+vectors.
 
 ## Advanced Configuration
 

--- a/gliner/decoding/decoder.py
+++ b/gliner/decoding/decoder.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
-from typing import Dict, List, Tuple, Union, Optional
+from typing import Any, Dict, List, Tuple, Union, Optional
 from functools import partial
-from dataclasses import dataclass
+from dataclasses import field, dataclass
 
 import torch
 
@@ -65,11 +65,15 @@ class Span:
 
     Attributes:
         start: Token-level start position (inclusive)
-        end: Token-level end position (exclusive)
+        end: Token-level end position (inclusive)
         entity_type: The entity type/label
         score: Confidence score for this prediction
         class_probs: Optional dict of top-k class probabilities
         generated_labels: Optional list of generated labels (for generative decoders)
+        class_index: Internal zero-based class index in the model output
+        span_index: Internal flattened/explicit span index in the model output
+        vector: Optional contextual span vector attached after decoding
+        label_vector: Optional matched label vector attached after decoding
     """
 
     start: int
@@ -78,6 +82,81 @@ class Span:
     score: float
     class_probs: Optional[Dict[str, float]] = None
     generated_labels: Optional[List[str]] = None
+    class_index: Optional[int] = field(default=None, compare=False, repr=False)
+    span_index: Optional[int] = field(default=None, compare=False, repr=False)
+    vector: Optional[Any] = field(default=None, compare=False, repr=False)
+    label_vector: Optional[Any] = field(default=None, compare=False, repr=False)
+
+
+class DecodedRelation(tuple):
+    """A decoded relation with internal model indices and optional vectors.
+
+    The tuple payload intentionally remains ``(head_idx, label, tail_idx, score)``
+    so existing indexing, iteration, unpacking, equality checks, JSON handling,
+    and ``len(relation) == 4`` continue to work.  The additional attributes are
+    decoder metadata used to gather the exact model representations after the
+    final relation candidates have been selected.
+    """
+
+    pair_index: Optional[int]
+    class_index: Optional[int]
+    vector: Optional[Any]
+    label_vector: Optional[Any]
+    head_relation_vector: Optional[Any]
+    tail_relation_vector: Optional[Any]
+
+    def __new__(
+        cls,
+        head_idx: int,
+        label: str,
+        tail_idx: int,
+        score: float,
+        *,
+        pair_index: Optional[int] = None,
+        class_index: Optional[int] = None,
+        vector: Optional[Any] = None,
+        label_vector: Optional[Any] = None,
+        head_relation_vector: Optional[Any] = None,
+        tail_relation_vector: Optional[Any] = None,
+    ) -> "DecodedRelation":
+        instance = super().__new__(cls, (head_idx, label, tail_idx, score))
+        instance.pair_index = pair_index
+        instance.class_index = class_index
+        instance.vector = vector
+        instance.label_vector = label_vector
+        instance.head_relation_vector = head_relation_vector
+        instance.tail_relation_vector = tail_relation_vector
+        return instance
+
+    def __getnewargs_ex__(self):
+        """Preserve tuple payload and metadata when copying or pickling."""
+        return (
+            (self.head_idx, self.label, self.tail_idx, self.score),
+            {
+                "pair_index": self.pair_index,
+                "class_index": self.class_index,
+                "vector": self.vector,
+                "label_vector": self.label_vector,
+                "head_relation_vector": self.head_relation_vector,
+                "tail_relation_vector": self.tail_relation_vector,
+            },
+        )
+
+    @property
+    def head_idx(self) -> int:
+        return self[0]
+
+    @property
+    def label(self) -> str:
+        return self[1]
+
+    @property
+    def tail_idx(self) -> int:
+        return self[2]
+
+    @property
+    def score(self) -> float:
+        return self[3]
 
 
 class BaseDecoder(ABC):
@@ -626,7 +705,15 @@ class SpanDecoder(BaseSpanDecoder):
             Span: Span object with entity properties.
         """
         ent_type = id_to_class[class_idx + 1]  # +1 because 0 is <pad>
-        return Span(start=start, end=start + width, entity_type=ent_type, score=score, class_probs=class_probs)
+        return Span(
+            start=start,
+            end=start + width,
+            entity_type=ent_type,
+            score=score,
+            class_probs=class_probs,
+            class_index=class_idx,
+            span_index=flat_idx,
+        )
 
     def _decode_explicit_spans(
         self,
@@ -696,7 +783,7 @@ class SpanDecoder(BaseSpanDecoder):
         candidate_boundaries = span_idx[batch_indices, span_positions]
         candidate_scores = probabilities[batch_indices, span_positions, class_indices]
         index_rows = (
-            torch.column_stack((batch_indices, candidate_boundaries, class_indices))
+            torch.column_stack((batch_indices, candidate_boundaries, class_indices, span_positions))
             .detach()
             .cpu()
             .tolist()
@@ -723,7 +810,7 @@ class SpanDecoder(BaseSpanDecoder):
             top_index_rows = top_indices.detach().cpu().tolist()
 
         candidates_by_batch = [[] for _ in range(batch_size)]
-        for row_index, ((batch_idx, start, end, class_idx), score) in enumerate(
+        for row_index, ((batch_idx, start, end, class_idx, span_position), score) in enumerate(
             zip(index_rows, score_rows)
         ):
             id_to_class = id_to_class_per_item[batch_idx]
@@ -744,6 +831,8 @@ class SpanDecoder(BaseSpanDecoder):
                     entity_type=id_to_class[class_idx + 1],
                     score=score,
                     class_probs=class_probs,
+                    class_index=class_idx,
+                    span_index=span_position,
                 )
             )
 
@@ -922,6 +1011,8 @@ class SpanGenerativeDecoder(BaseSpanDecoder):
             score=score,
             class_probs=class_probs,
             generated_labels=gen_ent_type,
+            class_index=class_idx,
+            span_index=flat_idx,
         )
 
     def decode_generative(
@@ -1132,6 +1223,7 @@ def _decode_relations_batch(
     head_list = head[b_idx, r_idx].tolist()
     tail_list = tail[b_idx, r_idx].tolist()
     b_list = b_idx.tolist()
+    r_list = r_idx.tolist()
     c_list = c_idx.tolist()
 
     # 6. Pure-Python grouping — no more GPU access
@@ -1141,7 +1233,16 @@ def _decode_relations_batch(
         mapping = rel_id_to_class_per_item[b]
         if c1 not in mapping:
             continue
-        relations[b].append((int(head_list[k]), mapping[c1], int(tail_list[k]), scores[k]))
+        relations[b].append(
+            DecodedRelation(
+                int(head_list[k]),
+                mapping[c1],
+                int(tail_list[k]),
+                scores[k],
+                pair_index=int(r_list[k]),
+                class_index=int(c_list[k]),
+            )
+        )
 
     return relations
 
@@ -1196,7 +1297,15 @@ class SpanRelexDecoder(BaseSpanDecoder):
             Span: Span object with entity properties.
         """
         ent_type = id_to_class[class_idx + 1]  # +1 because 0 is <pad>
-        return Span(start=start, end=start + width, entity_type=ent_type, score=score, class_probs=class_probs)
+        return Span(
+            start=start,
+            end=start + width,
+            entity_type=ent_type,
+            score=score,
+            class_probs=class_probs,
+            class_index=class_idx,
+            span_index=flat_idx,
+        )
 
     def _build_entity_span_to_decoded_idx(
         self,
@@ -1360,8 +1469,18 @@ class SpanRelexDecoder(BaseSpanDecoder):
 
                     rel_label = rel_id_to_class_i[c + 1]
 
-                    # Append relation: (head_idx, relation_label, tail_idx, score)
-                    relations[i].append((head_idx, rel_label, tail_idx, prob))
+                    # The tuple payload stays backwards-compatible while the
+                    # model-space indices remain available for vector gathering.
+                    relations[i].append(
+                        DecodedRelation(
+                            head_idx,
+                            rel_label,
+                            tail_idx,
+                            prob,
+                            pair_index=j,
+                            class_index=c,
+                        )
+                    )
 
         return relations
 
@@ -1513,7 +1632,17 @@ class TokenDecoder(BaseDecoder):
                     end_score = end_cpu[ed][cls_ed]
                     # The span score is the minimum value among all scores
                     spn_score = min(*ins, start_score, end_score)
-                    span_i.append(Span(start=st, end=ed, entity_type=id_to_classes[cls_st + 1], score=spn_score))
+                    span_i.append(
+                        Span(
+                            start=st,
+                            end=ed,
+                            entity_type=id_to_classes[cls_st + 1],
+                            score=spn_score,
+                            class_index=cls_st,
+                            # BIO decoding has no corresponding model span slot.
+                            span_index=None,
+                        )
+                    )
         return span_i
 
     def _decode_from_spans(
@@ -1594,7 +1723,16 @@ class TokenDecoder(BaseDecoder):
                     class_id = class_idx + 1  # Convert to 1-indexed
                     if class_id in id_to_class_i:
                         entity_type = id_to_class_i[class_id]
-                        span_scores.append(Span(start=span_start, end=span_end, entity_type=entity_type, score=prob))
+                        span_scores.append(
+                            Span(
+                                start=span_start,
+                                end=span_end,
+                                entity_type=entity_type,
+                                score=prob,
+                                class_index=class_idx,
+                                span_index=span_pos,
+                            )
+                        )
 
             # Apply greedy search to handle overlapping spans if needed
             span_i = self.greedy_search(span_scores, flat_ner_values[i], multi_label_values[i])
@@ -1880,7 +2018,16 @@ class TokenRelexDecoder(TokenDecoder):
                         continue
 
                     rel_label = rel_id_to_class_i[c + 1]
-                    relations[i].append((head_idx, rel_label, tail_idx, prob))
+                    relations[i].append(
+                        DecodedRelation(
+                            head_idx,
+                            rel_label,
+                            tail_idx,
+                            prob,
+                            pair_index=j,
+                            class_index=c,
+                        )
+                    )
 
         return relations
 
@@ -2102,7 +2249,17 @@ class TokenGenerativeDecoder(TokenDecoder, SpanGenerativeDecoder):
                     if class_id in id_to_class_i:
                         entity_type = id_to_class_i[class_id]
                         gen_label = span_label_map_i.get(span_pos)
-                        span_scores.append((span_start, span_end, entity_type, gen_label, prob))
+                        span_scores.append(
+                            Span(
+                                start=span_start,
+                                end=span_end,
+                                entity_type=entity_type,
+                                score=prob,
+                                generated_labels=gen_label,
+                                class_index=class_idx,
+                                span_index=span_pos,
+                            )
+                        )
 
             span_i = self.greedy_search(span_scores, flat_ner_values[i], multi_label_values[i])
             spans.append(span_i)

--- a/gliner/model.py
+++ b/gliner/model.py
@@ -190,6 +190,182 @@ def _remap_id_to_classes(batch, entity_types, label_names):
     batch["id_to_classes"] = remapped if isinstance(id_to_classes, list) else remapped[0]
 
 
+def _model_output_tensor(model_output, name: str) -> Optional[torch.Tensor]:
+    """Return an optional model-output value as a torch tensor."""
+    value = getattr(model_output, name, None)
+    if value is None:
+        return None
+    if isinstance(value, torch.Tensor):
+        return value
+    return torch.as_tensor(value)
+
+
+def _assign_vector_rows(requests, attribute: str) -> None:
+    """Bulk-copy selected embedding rows to decoded objects as float32 NumPy views."""
+    if not requests:
+        return
+    objects, tensors = zip(*requests)
+    values = torch.stack(tensors).detach().to(device="cpu", dtype=torch.float32).numpy()
+    for obj, value in zip(objects, values):
+        setattr(obj, attribute, value)
+
+
+def _assign_vector_tensor(objects, values: torch.Tensor, attribute: str) -> None:
+    """Bulk-copy an already stacked embedding tensor to decoded objects."""
+    if not objects:
+        return
+    numpy_values = values.detach().to(device="cpu", dtype=torch.float32).numpy()
+    for obj, value in zip(objects, numpy_values):
+        setattr(obj, attribute, value)
+
+
+def _attach_entity_vectors(
+    decoded: List[List[Any]],
+    model_output: Any,
+    config: Any,
+    return_vectors: bool,
+    return_label_vectors: bool,
+) -> None:
+    """Attach requested entity and label representations to final decoded spans."""
+    if not return_vectors and not return_label_vectors:
+        return
+    if not any(decoded):
+        return
+
+    words_embedding = _model_output_tensor(model_output, "words_embedding")
+    prompts_embedding = _model_output_tensor(model_output, "prompts_embedding")
+    span_embeddings = _model_output_tensor(model_output, "span_embeddings")
+    is_token_level = getattr(config, "span_mode", None) == "token_level"
+
+    if return_vectors and is_token_level and words_embedding is None:
+        raise RuntimeError("Token-level span vectors require words_embedding in the model output")
+    if return_vectors and not is_token_level and span_embeddings is None:
+        raise RuntimeError("Span vectors require span_embeddings in the model output")
+    if return_label_vectors and prompts_embedding is None:
+        raise RuntimeError("Label vectors require prompts_embedding in the model output")
+
+    flattened_span_embeddings = None
+    if return_vectors and not is_token_level:
+        if span_embeddings.ndim == 4:
+            flattened_span_embeddings = span_embeddings.flatten(1, 2)
+        elif span_embeddings.ndim == 3:
+            flattened_span_embeddings = span_embeddings
+        else:
+            raise RuntimeError(
+                "span_embeddings must have shape [batch, spans, hidden] or [batch, words, widths, hidden]"
+            )
+
+    vector_objects = []
+    vector_batch_indices = []
+    vector_span_indices = []
+    vector_starts = []
+    vector_ends = []
+    label_objects = []
+    label_batch_indices = []
+    label_class_indices = []
+    for batch_index, spans in enumerate(decoded):
+        for span in spans:
+            if return_vectors:
+                if is_token_level:
+                    if span.start < 0 or span.end < span.start or span.end >= words_embedding.size(1):
+                        raise RuntimeError(f"Decoded span [{span.start}, {span.end}] is outside the word embeddings")
+                    vector_starts.append(span.start)
+                    vector_ends.append(span.end)
+                else:
+                    span_index = getattr(span, "span_index", None)
+                    if span_index is None:
+                        raise RuntimeError("Decoded span is missing its model span index")
+                    vector_span_indices.append(span_index)
+                vector_objects.append(span)
+                vector_batch_indices.append(batch_index)
+
+            if return_label_vectors:
+                class_index = getattr(span, "class_index", None)
+                if class_index is None:
+                    raise RuntimeError("Decoded span is missing its model class index")
+                label_objects.append(span)
+                label_batch_indices.append(batch_index)
+                label_class_indices.append(class_index)
+
+    if vector_objects:
+        vector_batches = torch.tensor(
+            vector_batch_indices,
+            dtype=torch.long,
+            device=words_embedding.device if is_token_level else span_embeddings.device,
+        )
+        if is_token_level:
+            starts = torch.tensor(vector_starts, dtype=torch.long, device=words_embedding.device)
+            ends = torch.tensor(vector_ends, dtype=torch.long, device=words_embedding.device)
+            prefix = words_embedding.cumsum(dim=1, dtype=torch.float32)
+            prefix = torch.cat((torch.zeros_like(prefix[:, :1]), prefix), dim=1)
+            vector_values = prefix[vector_batches, ends + 1] - prefix[vector_batches, starts]
+            vector_values = vector_values / (ends - starts + 1).unsqueeze(-1)
+        else:
+            span_indices = torch.tensor(vector_span_indices, dtype=torch.long, device=span_embeddings.device)
+            vector_values = flattened_span_embeddings[vector_batches, span_indices]
+        _assign_vector_tensor(vector_objects, vector_values, "vector")
+
+    if label_objects:
+        label_batches = torch.tensor(label_batch_indices, dtype=torch.long, device=prompts_embedding.device)
+        label_indices = torch.tensor(label_class_indices, dtype=torch.long, device=prompts_embedding.device)
+        _assign_vector_tensor(label_objects, prompts_embedding[label_batches, label_indices], "label_vector")
+
+
+def _attach_relation_vectors(
+    decoded_relations: List[List[Any]],
+    model_output: Any,
+    return_vectors: bool,
+    return_label_vectors: bool,
+) -> None:
+    """Attach scorer-side representations to final decoded relations."""
+    if not return_vectors and not return_label_vectors:
+        return
+    if not any(decoded_relations):
+        return
+
+    relation_embeddings = _model_output_tensor(model_output, "relation_embeddings")
+    relation_head_embeddings = _model_output_tensor(model_output, "relation_head_embeddings")
+    relation_tail_embeddings = _model_output_tensor(model_output, "relation_tail_embeddings")
+    relation_prompts = _model_output_tensor(model_output, "rel_prompts_embedding")
+
+    if (
+        return_vectors
+        and relation_embeddings is None
+        and (relation_head_embeddings is None or relation_tail_embeddings is None)
+    ):
+        raise RuntimeError("Relation vectors require relation representations in the model output")
+    if return_label_vectors and relation_prompts is None:
+        raise RuntimeError("Relation label vectors require rel_prompts_embedding in the model output")
+
+    vector_requests = []
+    head_requests = []
+    tail_requests = []
+    label_requests = []
+    for batch_index, relations in enumerate(decoded_relations):
+        for relation in relations:
+            pair_index = getattr(relation, "pair_index", None)
+            class_index = getattr(relation, "class_index", None)
+            if return_vectors and pair_index is None:
+                raise RuntimeError("Decoded relation is missing its model pair index")
+
+            if return_vectors:
+                if relation_embeddings is not None:
+                    vector_requests.append((relation, relation_embeddings[batch_index, pair_index]))
+                else:
+                    head_requests.append((relation, relation_head_embeddings[batch_index, pair_index]))
+                    tail_requests.append((relation, relation_tail_embeddings[batch_index, pair_index]))
+
+            if return_label_vectors:
+                if class_index is None:
+                    raise RuntimeError("Decoded relation is missing its model class index")
+                label_requests.append((relation, relation_prompts[batch_index, class_index]))
+
+    _assign_vector_rows(vector_requests, "vector")
+    _assign_vector_rows(head_requests, "head_relation_vector")
+    _assign_vector_rows(tail_requests, "tail_relation_vector")
+    _assign_vector_rows(label_requests, "label_vector")
+
+
 def _get_trainer_classes():
     """Lazily import Trainer/TrainingArguments.
 
@@ -2505,6 +2681,12 @@ class BaseEncoderGLiNER(BaseGLiNER):
                 if span.class_probs is not None:
                     entity["class_probs"] = span.class_probs
 
+                if getattr(span, "vector", None) is not None:
+                    entity["vector"] = span.vector
+
+                if getattr(span, "label_vector", None) is not None:
+                    entity["label_vector"] = span.label_vector
+
                 entities.append(entity)
 
             all_entities[orig_i] = entities
@@ -2520,6 +2702,8 @@ class BaseEncoderGLiNER(BaseGLiNER):
         packing_config=None,
         return_class_probs=False,
         word_input_spans=None,
+        return_vectors=False,
+        return_label_vectors=False,
         **external_inputs,
     ):
         """Shared batch processing logic using modular run_batch and decode_batch."""
@@ -2527,13 +2711,15 @@ class BaseEncoderGLiNER(BaseGLiNER):
         batch_offset = 0
 
         for batch in data_loader:
-            model_output = self.run_batch(
-                batch,
-                threshold=threshold,
-                packing_config=packing_config,
-                move_to_device=True,
+            run_kwargs = {
+                "threshold": threshold,
+                "packing_config": packing_config,
+                "move_to_device": True,
                 **external_inputs,
-            )
+            }
+            if return_vectors:
+                run_kwargs["return_vectors"] = True
+            model_output = self.run_batch(batch, **run_kwargs)
 
             batch_input_spans = None
             if word_input_spans is not None:
@@ -2541,15 +2727,18 @@ class BaseEncoderGLiNER(BaseGLiNER):
                 batch_input_spans = word_input_spans[batch_offset : batch_offset + current_batch_size]
                 batch_offset += current_batch_size
 
-            decoded = self.decode_batch(
-                model_output,
-                batch,
-                threshold=threshold,
-                flat_ner=flat_ner,
-                multi_label=multi_label,
-                return_class_probs=return_class_probs,
-                input_spans=batch_input_spans,
-            )
+            decode_kwargs = {
+                "threshold": threshold,
+                "flat_ner": flat_ner,
+                "multi_label": multi_label,
+                "return_class_probs": return_class_probs,
+                "input_spans": batch_input_spans,
+            }
+            if return_vectors:
+                decode_kwargs["return_vectors"] = True
+            if return_label_vectors:
+                decode_kwargs["return_label_vectors"] = True
+            decoded = self.decode_batch(model_output, batch, **decode_kwargs)
             outputs.extend(decoded)
 
         return outputs
@@ -2673,6 +2862,7 @@ class BaseEncoderGLiNER(BaseGLiNER):
         threshold: float = 0.5,
         packing_config: Optional[InferencePackingConfig] = None,
         move_to_device: bool = True,
+        return_vectors: bool = False,
         **external_inputs,
     ) -> Any:
         """Run model forward pass on a collated batch.
@@ -2682,6 +2872,7 @@ class BaseEncoderGLiNER(BaseGLiNER):
             threshold: Confidence threshold for predictions.
             packing_config: Optional inference packing configuration.
             move_to_device: Whether to move tensors to model device.
+            return_vectors: Whether to retain span representations for decoding.
             **external_inputs: Additional inputs to pass to the model.
 
         Returns:
@@ -2708,6 +2899,8 @@ class BaseEncoderGLiNER(BaseGLiNER):
         else:
             model_inputs = batch
 
+        if return_vectors:
+            model_inputs = {**model_inputs, "return_embeddings": True}
         model_output = self.model(**model_inputs, threshold=threshold)
         return model_output
 
@@ -2720,6 +2913,8 @@ class BaseEncoderGLiNER(BaseGLiNER):
         multi_label: Union[bool, List[bool]] = False,
         return_class_probs: bool = False,
         input_spans: Optional[List[List[Tuple[int, int]]]] = None,
+        return_vectors: bool = False,
+        return_label_vectors: bool = False,
     ) -> List[List[Any]]:
         """Decode model output into entity predictions.
 
@@ -2731,6 +2926,8 @@ class BaseEncoderGLiNER(BaseGLiNER):
             multi_label: Whether to allow multiple labels per span.
             return_class_probs: Whether to include class probabilities.
             input_spans: Optional word-level input spans to classify.
+            return_vectors: Whether to attach a contextual vector to every returned span.
+            return_label_vectors: Whether to attach the matched scoring-time label vector.
 
         Returns:
             List of entity lists (one per text in batch).
@@ -2751,6 +2948,13 @@ class BaseEncoderGLiNER(BaseGLiNER):
             multi_label=multi_label,
             return_class_probs=return_class_probs,
             input_spans=input_spans,
+        )
+        _attach_entity_vectors(
+            decoded,
+            model_output,
+            self.config,
+            return_vectors=return_vectors,
+            return_label_vectors=return_label_vectors,
         )
         return decoded
 
@@ -2814,6 +3018,9 @@ class BaseEncoderGLiNER(BaseGLiNER):
         packing_config: Optional[InferencePackingConfig] = None,
         input_spans: Optional[List[List[Dict]]] = None,
         return_class_probs: bool = False,
+        *,
+        return_vectors: bool = False,
+        return_label_vectors: bool = False,
         **external_inputs,
     ) -> List[List[Dict[str, Any]]]:
         """Predict entities for a batch of texts.
@@ -2829,6 +3036,8 @@ class BaseEncoderGLiNER(BaseGLiNER):
                 the instance-level configuration set via configure_inference_packing is used.
             input_spans: Input entity spans that should be classified by the model.
             return_class_probs: Whether to include class probabilities in output. Defaults to False.
+            return_vectors: Whether to include a contextual vector for each returned entity.
+            return_label_vectors: Whether to include the matched label vector for each entity.
             **external_inputs: Additional inputs to pass to the model.
 
         Returns:
@@ -2841,6 +3050,11 @@ class BaseEncoderGLiNER(BaseGLiNER):
                 - class_probs: (optional) Dictionary mapping class names to probabilities (top 5)
         """
         self.eval()
+
+        if (return_vectors or return_label_vectors) and self.is_runtime_model:
+            raise NotImplementedError(
+                "Entity and label vectors are not available from the current ONNX/OpenVINO exports"
+            )
 
         prepared = self.prepare_batch(texts, labels, input_spans)
 
@@ -2893,6 +3107,8 @@ class BaseEncoderGLiNER(BaseGLiNER):
             packing_config=active_packing,
             return_class_probs=return_class_probs,
             word_input_spans=prepared["word_input_spans"],
+            return_vectors=return_vectors,
+            return_label_vectors=return_label_vectors,
             **external_inputs,
         )
 
@@ -2915,6 +3131,9 @@ class BaseEncoderGLiNER(BaseGLiNER):
         threshold: float = 0.5,
         multi_label: bool = False,
         return_class_probs: bool = False,
+        *,
+        return_vectors: bool = False,
+        return_label_vectors: bool = False,
         **kwargs,
     ) -> List[Dict[str, Any]]:
         """Predict entities for a single text input.
@@ -2926,6 +3145,8 @@ class BaseEncoderGLiNER(BaseGLiNER):
             threshold: Confidence threshold for predictions. Defaults to 0.5.
             multi_label: Whether to allow multiple labels per entity. Defaults to False.
             return_class_probs: Whether to include class probabilities in output. Defaults to False.
+            return_vectors: Whether to include a contextual vector for each returned entity.
+            return_label_vectors: Whether to include the matched label vector for each entity.
             **kwargs: Additional arguments passed to inference.
 
         Returns:
@@ -2938,6 +3159,8 @@ class BaseEncoderGLiNER(BaseGLiNER):
             threshold=threshold,
             multi_label=multi_label,
             return_class_probs=return_class_probs,
+            return_vectors=return_vectors,
+            return_label_vectors=return_label_vectors,
             **kwargs,
         )[0]
 
@@ -2948,6 +3171,9 @@ class BaseEncoderGLiNER(BaseGLiNER):
         flat_ner: bool = True,
         threshold: float = 0.5,
         multi_label: bool = False,
+        *,
+        return_vectors: bool = False,
+        return_label_vectors: bool = False,
         **kwargs,
     ) -> List[List[Dict[str, Any]]]:
         """Predict entities for multiple texts.
@@ -2963,6 +3189,8 @@ class BaseEncoderGLiNER(BaseGLiNER):
             flat_ner: Use flat NER. Defaults to True.
             threshold: Confidence threshold. Defaults to 0.5.
             multi_label: Allow multiple labels per token/entity. Defaults to False.
+            return_vectors: Whether to include a contextual vector for each returned entity.
+            return_label_vectors: Whether to include the matched label vector for each entity.
             **kwargs: Extra arguments forwarded to inference (e.g., batch_size).
 
         Returns:
@@ -2980,6 +3208,8 @@ class BaseEncoderGLiNER(BaseGLiNER):
             flat_ner=flat_ner,
             threshold=threshold,
             multi_label=multi_label,
+            return_vectors=return_vectors,
+            return_label_vectors=return_label_vectors,
             **kwargs,
         )
 
@@ -3298,6 +3528,9 @@ class BaseBiEncoderGLiNER(BaseEncoderGLiNER):
         packing_config: Optional[InferencePackingConfig] = None,
         input_spans: Optional[List[List[Dict]]] = None,
         return_class_probs: bool = False,
+        *,
+        return_vectors: bool = False,
+        return_label_vectors: bool = False,
     ) -> List[List[Dict[str, Any]]]:
         """Predict entities for a batch of texts using pre-computed label embeddings.
 
@@ -3314,10 +3547,17 @@ class BaseBiEncoderGLiNER(BaseEncoderGLiNER):
             input_spans: Input entity spans to limit predictions to. Each span is a dict
                 with 'start' and 'end' character positions.
             return_class_probs: Whether to include class probabilities in output. Defaults to False.
+            return_vectors: Whether to include a contextual vector for each returned entity.
+            return_label_vectors: Whether to include the matched label vector for each entity.
 
         Returns:
             List of lists with predicted entities.
         """
+        embedding_input = (
+            {"labels_embeddings": labels_embeddings}
+            if self.is_runtime_model
+            else {"labels_embeds": labels_embeddings}
+        )
         all_entities = self.inference(
             texts,
             labels,
@@ -3328,7 +3568,9 @@ class BaseBiEncoderGLiNER(BaseEncoderGLiNER):
             packing_config=packing_config,
             input_spans=input_spans,
             return_class_probs=return_class_probs,
-            labels_embeddings=labels_embeddings,
+            return_vectors=return_vectors,
+            return_label_vectors=return_label_vectors,
+            **embedding_input,
         )
 
         return all_entities
@@ -3342,6 +3584,9 @@ class BaseBiEncoderGLiNER(BaseEncoderGLiNER):
         threshold=0.5,
         multi_label=False,
         return_class_probs=False,
+        *,
+        return_vectors=False,
+        return_label_vectors=False,
         **kwargs,
     ):
         """Predict entities for a single text input using pre-computed label embeddings.
@@ -3354,6 +3599,8 @@ class BaseBiEncoderGLiNER(BaseEncoderGLiNER):
             threshold: Confidence threshold for predictions. Defaults to 0.5.
             multi_label: Whether to allow multiple labels per entity. Defaults to False.
             return_class_probs: Whether to include class probabilities in output. Defaults to False.
+            return_vectors: Whether to include a contextual vector for each returned entity.
+            return_label_vectors: Whether to include the matched label vector for each entity.
             **kwargs: Additional arguments passed to batch_predict_with_embeds.
 
         Returns:
@@ -3367,6 +3614,8 @@ class BaseBiEncoderGLiNER(BaseEncoderGLiNER):
             threshold=threshold,
             multi_label=multi_label,
             return_class_probs=return_class_probs,
+            return_vectors=return_vectors,
+            return_label_vectors=return_label_vectors,
             **kwargs,
         )[0]
 
@@ -4755,6 +5004,9 @@ class StreamingSpanGLiNER(BaseEncoderGLiNER):
         return_class_probs: bool = False,
         session_id: Optional[List[str]] = None,
         recompute: bool = False,
+        *,
+        return_vectors: bool = False,
+        return_label_vectors: bool = False,
         **external_inputs,
     ):
         """Run stateless inference or append to cached streaming-span sessions.
@@ -4776,7 +5028,14 @@ class StreamingSpanGLiNER(BaseEncoderGLiNER):
                 packing_config=packing_config,
                 input_spans=input_spans,
                 return_class_probs=return_class_probs,
+                return_vectors=return_vectors,
+                return_label_vectors=return_label_vectors,
                 **external_inputs,
+            )
+        if return_vectors or return_label_vectors:
+            raise NotImplementedError(
+                "Entity and label vectors are not yet available for stateful streaming inference; "
+                "use stateless inference or recompute outside a session"
             )
         if external_inputs:
             raise ValueError("external model inputs are not supported with session inference")
@@ -5068,6 +5327,7 @@ class UniEncoderSpanDecoderGLiNER(BaseEncoderGLiNER):
         move_to_device: bool = True,
         gen_constraints: Optional[List[str]] = None,
         num_gen_sequences: int = 1,
+        return_vectors: bool = False,
         **gen_kwargs,
     ) -> Any:
         """Run model forward pass on a collated batch with label generation.
@@ -5079,6 +5339,7 @@ class UniEncoderSpanDecoderGLiNER(BaseEncoderGLiNER):
             move_to_device: Whether to move tensors to model device.
             gen_constraints: Labels to constrain generation.
             num_gen_sequences: Number of label sequences to generate per span.
+            return_vectors: Whether to retain span representations for decoding.
             **gen_kwargs: Additional generation parameters.
 
         Returns:
@@ -5088,6 +5349,8 @@ class UniEncoderSpanDecoderGLiNER(BaseEncoderGLiNER):
             batch = {k: v.to(self.device) if isinstance(v, torch.Tensor) else v for k, v in batch.items()}
 
         model_inputs = batch.copy() if packing_config is None else {**batch, "packing_config": packing_config}
+        if return_vectors:
+            model_inputs["return_embeddings"] = True
         model_output = self.model(**model_inputs, threshold=threshold)
 
         # Generate labels if decoder is available
@@ -5114,6 +5377,8 @@ class UniEncoderSpanDecoderGLiNER(BaseEncoderGLiNER):
         multi_label: Union[bool, List[bool]] = False,
         return_class_probs: bool = False,
         input_spans: Optional[List[List[Tuple[int, int]]]] = None,
+        return_vectors: bool = False,
+        return_label_vectors: bool = False,
     ) -> List[List[Any]]:
         """Decode model output into entity predictions with generated labels.
 
@@ -5125,6 +5390,8 @@ class UniEncoderSpanDecoderGLiNER(BaseEncoderGLiNER):
             multi_label: Whether to allow multiple labels per span.
             return_class_probs: Whether to include class probabilities.
             input_spans: Optional word-level input spans to classify.
+            return_vectors: Whether to attach a contextual vector to every returned span.
+            return_label_vectors: Whether to attach the matched scoring-time label vector.
 
         Returns:
             List of entity lists (one per text in batch).
@@ -5143,8 +5410,18 @@ class UniEncoderSpanDecoderGLiNER(BaseEncoderGLiNER):
             gen_labels=model_output.gen_labels,
             sel_idx=model_output.decoder_span_idx,
             num_gen_sequences=model_output.num_gen_sequences,
+            span_logits=model_output.span_logits,
+            span_idx=model_output.span_idx,
+            span_mask=model_output.span_mask,
             return_class_probs=return_class_probs,
             input_spans=input_spans,
+        )
+        _attach_entity_vectors(
+            decoded,
+            model_output,
+            self.config,
+            return_vectors=return_vectors,
+            return_label_vectors=return_label_vectors,
         )
         return decoded
 
@@ -5159,6 +5436,8 @@ class UniEncoderSpanDecoderGLiNER(BaseEncoderGLiNER):
         word_input_spans=None,
         gen_constraints=None,
         num_gen_sequences=1,
+        return_vectors=False,
+        return_label_vectors=False,
         **gen_kwargs,
     ):
         """Batch processing logic with label generation support."""
@@ -5173,6 +5452,7 @@ class UniEncoderSpanDecoderGLiNER(BaseEncoderGLiNER):
                 move_to_device=True,
                 gen_constraints=gen_constraints,
                 num_gen_sequences=num_gen_sequences,
+                return_vectors=return_vectors,
                 **gen_kwargs,
             )
 
@@ -5190,6 +5470,8 @@ class UniEncoderSpanDecoderGLiNER(BaseEncoderGLiNER):
                 multi_label=multi_label,
                 return_class_probs=return_class_probs,
                 input_spans=batch_input_spans,
+                return_vectors=return_vectors,
+                return_label_vectors=return_label_vectors,
             )
             outputs.extend(decoded)
 
@@ -5243,6 +5525,12 @@ class UniEncoderSpanDecoderGLiNER(BaseEncoderGLiNER):
                 if span.class_probs is not None:
                     entity["class_probs"] = span.class_probs
 
+                if getattr(span, "vector", None) is not None:
+                    entity["vector"] = span.vector
+
+                if getattr(span, "label_vector", None) is not None:
+                    entity["label_vector"] = span.label_vector
+
                 entities.append(entity)
 
             all_entities[orig_i] = entities
@@ -5263,6 +5551,9 @@ class UniEncoderSpanDecoderGLiNER(BaseEncoderGLiNER):
         packing_config: Optional[InferencePackingConfig] = None,
         input_spans: Optional[List[List[Dict]]] = None,
         return_class_probs: bool = False,
+        *,
+        return_vectors: bool = False,
+        return_label_vectors: bool = False,
         **gen_kwargs,
     ) -> List[List[Dict[str, Any]]]:
         """Predict entities with optional label generation.
@@ -5280,12 +5571,17 @@ class UniEncoderSpanDecoderGLiNER(BaseEncoderGLiNER):
             input_spans: Input entity spans to limit predictions to. Each span is a dict
                 with 'start' and 'end' character positions.
             return_class_probs: Whether to include class probabilities in output. Defaults to False.
+            return_vectors: Whether to include a contextual vector for each returned entity.
+            return_label_vectors: Whether to include the matched label vector for each entity.
             **gen_kwargs: Additional generation parameters.
 
         Returns:
             List of entity predictions with optional generated labels.
         """
         self.eval()
+
+        if (return_vectors or return_label_vectors) and self.is_runtime_model:
+            raise NotImplementedError("Entity and label vectors are not available from the current runtime exports")
 
         prepared = self.prepare_batch(texts, labels, input_spans)
 
@@ -5325,6 +5621,8 @@ class UniEncoderSpanDecoderGLiNER(BaseEncoderGLiNER):
             word_input_spans=prepared["word_input_spans"],
             gen_constraints=gen_constraints,
             num_gen_sequences=num_gen_sequences,
+            return_vectors=return_vectors,
+            return_label_vectors=return_label_vectors,
             **gen_kwargs,
         )
 
@@ -5349,6 +5647,9 @@ class UniEncoderSpanDecoderGLiNER(BaseEncoderGLiNER):
         gen_constraints: Optional[List[str]] = None,
         num_gen_sequences: int = 1,
         return_class_probs: bool = False,
+        *,
+        return_vectors: bool = False,
+        return_label_vectors: bool = False,
         **gen_kwargs,
     ) -> List[Dict[str, Any]]:
         """Predict entities for a single text input with optional label generation.
@@ -5362,6 +5663,8 @@ class UniEncoderSpanDecoderGLiNER(BaseEncoderGLiNER):
             gen_constraints: Labels to constrain generation.
             num_gen_sequences: Number of label sequences to generate per span.
             return_class_probs: Whether to include class probabilities in output. Defaults to False.
+            return_vectors: Whether to include a contextual vector for each returned entity.
+            return_label_vectors: Whether to include the matched label vector for each entity.
             **gen_kwargs: Additional generation parameters.
 
         Returns:
@@ -5376,6 +5679,8 @@ class UniEncoderSpanDecoderGLiNER(BaseEncoderGLiNER):
             gen_constraints=gen_constraints,
             num_gen_sequences=num_gen_sequences,
             return_class_probs=return_class_probs,
+            return_vectors=return_vectors,
+            return_label_vectors=return_label_vectors,
             **gen_kwargs,
         )[0]
 
@@ -5554,6 +5859,7 @@ class UniEncoderSpanRelexGLiNER(BaseEncoderGLiNER):
         adjacency_threshold: Optional[float] = None,
         packing_config: Optional[InferencePackingConfig] = None,
         move_to_device: bool = True,
+        return_vectors: bool = False,
         **external_inputs,
     ) -> Any:
         """Run model forward pass on a collated batch.
@@ -5564,6 +5870,7 @@ class UniEncoderSpanRelexGLiNER(BaseEncoderGLiNER):
             adjacency_threshold: Threshold for adjacency matrix reconstruction.
             packing_config: Optional inference packing configuration.
             move_to_device: Whether to move tensors to model device.
+            return_vectors: Whether to retain entity and relation representations for decoding.
             **external_inputs: Additional inputs to pass to the model.
 
         Returns:
@@ -5582,6 +5889,8 @@ class UniEncoderSpanRelexGLiNER(BaseEncoderGLiNER):
         else:
             model_inputs = batch
 
+        if return_vectors:
+            model_inputs = {**model_inputs, "return_embeddings": True}
         model_output = self.model(**model_inputs, threshold=threshold, adjacency_threshold=adjacency_threshold)
         return model_output
 
@@ -5595,6 +5904,8 @@ class UniEncoderSpanRelexGLiNER(BaseEncoderGLiNER):
         multi_label: Union[bool, List[bool]] = False,
         return_class_probs: bool = False,
         input_spans: Optional[List[List[Tuple[int, int]]]] = None,
+        return_vectors: bool = False,
+        return_label_vectors: bool = False,
     ) -> Tuple[List[List[Any]], List[List[Any]]]:
         """Decode model output into entity and relation predictions.
 
@@ -5607,6 +5918,8 @@ class UniEncoderSpanRelexGLiNER(BaseEncoderGLiNER):
             multi_label: Whether to allow multiple labels per span.
             return_class_probs: Whether to include class probabilities.
             input_spans: Optional word-level input spans to classify.
+            return_vectors: Whether to attach entity and relation representations.
+            return_label_vectors: Whether to attach matched entity and relation label vectors.
 
         Returns:
             Tuple of (entity_outputs, relation_outputs) where each is a list per text.
@@ -5647,6 +5960,8 @@ class UniEncoderSpanRelexGLiNER(BaseEncoderGLiNER):
             multi_label=multi_label,
             rel_id_to_classes=batch["rel_id_to_classes"],
             entity_spans=entity_spans,
+            return_class_probs=return_class_probs,
+            input_spans=input_spans,
         )
 
         if len(decoded_results) == 2:
@@ -5654,6 +5969,20 @@ class UniEncoderSpanRelexGLiNER(BaseEncoderGLiNER):
         else:
             decoded_entities = decoded_results
             decoded_relations = [[] for _ in range(len(batch["tokens"]))]
+
+        _attach_entity_vectors(
+            decoded_entities,
+            model_output,
+            self.config,
+            return_vectors=return_vectors,
+            return_label_vectors=return_label_vectors,
+        )
+        _attach_relation_vectors(
+            decoded_relations,
+            model_output,
+            return_vectors=return_vectors,
+            return_label_vectors=return_label_vectors,
+        )
 
         return decoded_entities, decoded_relations
 
@@ -5669,6 +5998,8 @@ class UniEncoderSpanRelexGLiNER(BaseEncoderGLiNER):
         adjacency_threshold=None,
         relation_threshold=None,
         return_relations=True,
+        return_vectors=False,
+        return_label_vectors=False,
         **external_inputs,
     ):
         """Batch processing logic for entity and relation extraction."""
@@ -5683,6 +6014,7 @@ class UniEncoderSpanRelexGLiNER(BaseEncoderGLiNER):
                 adjacency_threshold=adjacency_threshold,
                 packing_config=packing_config,
                 move_to_device=True,
+                return_vectors=return_vectors,
                 **external_inputs,
             )
 
@@ -5701,6 +6033,8 @@ class UniEncoderSpanRelexGLiNER(BaseEncoderGLiNER):
                 multi_label=multi_label,
                 return_class_probs=return_class_probs,
                 input_spans=batch_input_spans,
+                return_vectors=return_vectors,
+                return_label_vectors=return_label_vectors,
             )
 
             all_entity_outputs.extend(decoded_entities)
@@ -5756,6 +6090,12 @@ class UniEncoderSpanRelexGLiNER(BaseEncoderGLiNER):
 
                 if span.class_probs is not None:
                     entity["class_probs"] = span.class_probs
+
+                if getattr(span, "vector", None) is not None:
+                    entity["vector"] = span.vector
+
+                if getattr(span, "label_vector", None) is not None:
+                    entity["label_vector"] = span.label_vector
 
                 entities.append(entity)
 
@@ -5813,6 +6153,9 @@ class UniEncoderSpanRelexGLiNER(BaseEncoderGLiNER):
         input_spans: Optional[List[List[Dict]]] = None,
         return_relations: bool = True,
         return_class_probs: bool = False,
+        *,
+        return_vectors: bool = False,
+        return_label_vectors: bool = False,
     ) -> Union[List[List[Dict[str, Any]]], Tuple[List[List[Dict[str, Any]]], List[List[Dict[str, Any]]]]]:
         """Predict entities and relations.
 
@@ -5831,11 +6174,18 @@ class UniEncoderSpanRelexGLiNER(BaseEncoderGLiNER):
                 with 'start' and 'end' character positions.
             return_relations: Whether to return relation predictions.
             return_class_probs: Whether to include class probabilities in output. Defaults to False.
+            return_vectors: Whether to include contextual entity and relation representations.
+            return_label_vectors: Whether to include matched entity and relation label vectors.
 
         Returns:
             Tuple of (entities, relations) if return_relations=True, else just entities.
         """
         self.eval()
+
+        if (return_vectors or return_label_vectors) and self.is_runtime_model:
+            raise NotImplementedError(
+                "Entity, label, and relation vectors are not available from the current ONNX/OpenVINO exports"
+            )
 
         prepared = self.prepare_batch(texts, labels, input_spans, relations)
 
@@ -5885,6 +6235,8 @@ class UniEncoderSpanRelexGLiNER(BaseEncoderGLiNER):
             adjacency_threshold=adjacency_threshold,
             relation_threshold=relation_threshold,
             return_relations=return_relations,
+            return_vectors=return_vectors,
+            return_label_vectors=return_label_vectors,
         )
 
         all_entities = self.map_entities_to_text(
@@ -5920,6 +6272,9 @@ class UniEncoderSpanRelexGLiNER(BaseEncoderGLiNER):
         adjacency_threshold: Optional[float] = None,
         multi_label: bool = False,
         return_class_probs: bool = False,
+        *,
+        return_vectors: bool = False,
+        return_label_vectors: bool = False,
         **kwargs,
     ) -> List[Dict[str, Any]]:
         """Predict entities for a single text input.
@@ -5933,6 +6288,8 @@ class UniEncoderSpanRelexGLiNER(BaseEncoderGLiNER):
             adjacency_threshold: Threshold for adjacency matrix reconstruction. Defaults to threshold.
             multi_label: Whether to allow multiple labels per entity. Defaults to False.
             return_class_probs: Whether to include class probabilities in output. Defaults to False.
+            return_vectors: Whether to include a contextual vector for each returned entity.
+            return_label_vectors: Whether to include the matched label vector for each entity.
             **kwargs: Additional arguments passed to inference.
 
         Returns:
@@ -5948,6 +6305,8 @@ class UniEncoderSpanRelexGLiNER(BaseEncoderGLiNER):
             multi_label=multi_label,
             return_relations=False,
             return_class_probs=return_class_probs,
+            return_vectors=return_vectors,
+            return_label_vectors=return_label_vectors,
             **kwargs,
         )[0]
 
@@ -5961,6 +6320,9 @@ class UniEncoderSpanRelexGLiNER(BaseEncoderGLiNER):
         adjacency_threshold: Optional[float] = None,
         relation_threshold: Optional[float] = None,
         multi_label: bool = False,
+        *,
+        return_vectors: bool = False,
+        return_label_vectors: bool = False,
         **kwargs,
     ) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
         """Predict entities and relations for a single text input.
@@ -5974,6 +6336,8 @@ class UniEncoderSpanRelexGLiNER(BaseEncoderGLiNER):
             adjacency_threshold: Threshold for adjacency matrix reconstruction. Defaults to threshold.
             relation_threshold: Confidence threshold for relations. Defaults to threshold.
             multi_label: Whether to allow multiple labels per entity. Defaults to False.
+            return_vectors: Whether to include contextual entity and relation representations.
+            return_label_vectors: Whether to include matched entity and relation label vectors.
             **kwargs: Additional arguments passed to inference.
 
         Returns:
@@ -5989,6 +6353,8 @@ class UniEncoderSpanRelexGLiNER(BaseEncoderGLiNER):
             relation_threshold=relation_threshold,
             multi_label=multi_label,
             return_relations=True,
+            return_vectors=return_vectors,
+            return_label_vectors=return_label_vectors,
             **kwargs,
         )
         return entities[0], rels[0]
@@ -6039,7 +6405,8 @@ class UniEncoderSpanRelexGLiNER(BaseEncoderGLiNER):
             end_token_idx_to_text_idx = all_end_token_idx_to_text_idx[valid_i]
 
             # Process each relation tuple from decoder
-            for head_idx, relation_label, tail_idx, score in rel_tuples:
+            for relation_output in rel_tuples:
+                head_idx, relation_label, tail_idx, score = relation_output
                 # Validate entity indices
                 if head_idx >= len(entities_list) or tail_idx >= len(entities_list):
                     continue
@@ -6054,26 +6421,35 @@ class UniEncoderSpanRelexGLiNER(BaseEncoderGLiNER):
                 tail_start_text = start_token_idx_to_text_idx[tail_span.start]
                 tail_end_text = end_token_idx_to_text_idx[tail_span.end]
 
-                relations.append(
-                    {
-                        "head": {
-                            "start": head_start_text,
-                            "end": head_end_text,
-                            "text": valid_texts[valid_i][head_start_text:head_end_text],
-                            "type": head_span.entity_type,
-                            "entity_idx": head_idx,
-                        },
-                        "tail": {
-                            "start": tail_start_text,
-                            "end": tail_end_text,
-                            "text": valid_texts[valid_i][tail_start_text:tail_end_text],
-                            "type": tail_span.entity_type,
-                            "entity_idx": tail_idx,
-                        },
-                        "relation": relation_label,
-                        "score": score,
-                    }
-                )
+                relation = {
+                    "head": {
+                        "start": head_start_text,
+                        "end": head_end_text,
+                        "text": valid_texts[valid_i][head_start_text:head_end_text],
+                        "type": head_span.entity_type,
+                        "entity_idx": head_idx,
+                    },
+                    "tail": {
+                        "start": tail_start_text,
+                        "end": tail_end_text,
+                        "text": valid_texts[valid_i][tail_start_text:tail_end_text],
+                        "type": tail_span.entity_type,
+                        "entity_idx": tail_idx,
+                    },
+                    "relation": relation_label,
+                    "score": score,
+                }
+
+                if getattr(relation_output, "vector", None) is not None:
+                    relation["vector"] = relation_output.vector
+                if getattr(relation_output, "label_vector", None) is not None:
+                    relation["label_vector"] = relation_output.label_vector
+                if getattr(relation_output, "head_relation_vector", None) is not None:
+                    relation["head_relation_vector"] = relation_output.head_relation_vector
+                if getattr(relation_output, "tail_relation_vector", None) is not None:
+                    relation["tail_relation_vector"] = relation_output.tail_relation_vector
+
+                relations.append(relation)
 
             all_relations[orig_i] = relations
 

--- a/gliner/model.py
+++ b/gliner/model.py
@@ -3,7 +3,7 @@ import json
 import logging
 import warnings
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Union, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Union, Mapping, Optional
 from pathlib import Path
 from threading import RLock
 
@@ -104,6 +104,60 @@ from .data_processing.collator import (
 )
 from .data_processing.tokenizer import WordsSplitter
 
+EntityLabels = Union[
+    str,
+    List[str],
+    Mapping[str, str],
+    List[List[str]],
+    List[Mapping[str, str]],
+]
+
+
+def _normalize_label_set(labels):
+    """Return model-facing prompts and the corresponding public label names."""
+    if isinstance(labels, Mapping):
+        prompts = []
+        names = []
+        for name, prompt in labels.items():
+            if not isinstance(name, str) or not isinstance(prompt, str):
+                raise TypeError("Label description mappings must contain only string keys and values")
+            names.append(name)
+            prompts.append(prompt)
+        if len(set(prompts)) != len(prompts):
+            raise ValueError("Label descriptions must be unique within each label set")
+        return prompts, names
+
+    if isinstance(labels, str):
+        labels = [labels]
+
+    normalized = list(dict.fromkeys(labels))
+    return normalized, normalized
+
+
+def _normalize_labels(labels, num_texts, valid_to_orig_idx):
+    """Normalize shared or per-text labels while preserving empty-text alignment."""
+    is_per_text = isinstance(labels, list) and bool(labels) and any(
+        isinstance(label_set, (list, Mapping)) for label_set in labels
+    )
+    if not is_per_text:
+        return _normalize_label_set(labels)
+
+    if len(labels) != num_texts:
+        raise ValueError(f"Per-text labels must have length {num_texts}, got {len(labels)}")
+    if not all(isinstance(label_set, (list, Mapping)) for label_set in labels):
+        raise TypeError("Per-text labels must contain only lists or label description mappings")
+
+    normalized = [_normalize_label_set(label_set) for label_set in labels]
+    prompts = [normalized[index][0] for index in valid_to_orig_idx]
+    names = [normalized[index][1] for index in valid_to_orig_idx]
+    return prompts, names
+
+
+def _has_label_descriptions(labels):
+    return isinstance(labels, Mapping) or (
+        isinstance(labels, list) and any(isinstance(label_set, Mapping) for label_set in labels)
+    )
+
 
 def _entity_types_for_chunk(entity_types, indices):
     """Select the label sets belonging to the rows in one DataLoader chunk.
@@ -115,6 +169,25 @@ def _entity_types_for_chunk(entity_types, indices):
     if entity_types and isinstance(entity_types[0], list):
         return [entity_types[i] for i in indices]
     return entity_types
+
+
+def _remap_id_to_classes(batch, entity_types, label_names):
+    """Replace prompt text in decoder mappings with public label names."""
+    id_to_classes = batch.get("id_to_classes")
+    if id_to_classes is None or label_names is None:
+        return
+
+    mappings = id_to_classes if isinstance(id_to_classes, list) else [id_to_classes]
+    per_text = bool(entity_types) and isinstance(entity_types[0], list)
+    prompt_sets = entity_types if per_text else [entity_types] * len(mappings)
+    name_sets = label_names if per_text else [label_names] * len(mappings)
+
+    remapped = []
+    for mapping, prompts, names in zip(mappings, prompt_sets, name_sets):
+        prompt_to_name = dict(zip(prompts, names))
+        remapped.append({class_id: prompt_to_name.get(prompt, prompt) for class_id, prompt in mapping.items()})
+
+    batch["id_to_classes"] = remapped if isinstance(id_to_classes, list) else remapped[0]
 
 
 def _get_trainer_classes():
@@ -2484,7 +2557,7 @@ class BaseEncoderGLiNER(BaseGLiNER):
     def prepare_batch(
         self,
         texts: Union[str, List[str]],
-        labels: Union[str, List[str], List[List[str]]],
+        labels: EntityLabels,
         input_spans: Optional[List[List[Dict]]] = None,
         **kwargs,
     ) -> Dict[str, Any]:
@@ -2495,7 +2568,7 @@ class BaseEncoderGLiNER(BaseGLiNER):
 
         Args:
             texts: Single text string or list of texts.
-            labels: Entity labels - string, list of strings, or per-text label lists.
+            labels: Entity labels as strings, a label-to-description mapping, or per-text label sets.
             input_spans: Optional pre-defined spans to classify (character positions).
             **kwargs: Additional keyword arguments passed to the data processor.
 
@@ -2506,7 +2579,8 @@ class BaseEncoderGLiNER(BaseGLiNER):
                 - start_token_map: Per-text mapping from token idx to char start
                 - end_token_map: Per-text mapping from token idx to char end
                 - word_input_spans: Spans converted to word indices (or None)
-                - entity_types: Normalized entity types
+                - entity_types: Model-facing entity prompts
+                - label_names: Public entity label names
                 - valid_texts: Non-empty texts that will be processed
                 - valid_to_orig_idx: Mapping from valid indices to original indices
                 - num_original: Total number of original texts
@@ -2514,8 +2588,15 @@ class BaseEncoderGLiNER(BaseGLiNER):
         if isinstance(texts, str):
             texts = [texts]
 
+        if (
+            getattr(getattr(self, "config", None), "precomputed_prompts_mode", False)
+            and _has_label_descriptions(labels)
+        ):
+            raise ValueError("Label descriptions are not supported with precomputed prompt embeddings")
+
         num_original = len(texts)
         valid_texts, valid_to_orig_idx = self._filter_valid_texts(texts)
+        entity_types, label_names = _normalize_labels(labels, num_original, valid_to_orig_idx)
 
         if not valid_texts:
             return {
@@ -2525,20 +2606,11 @@ class BaseEncoderGLiNER(BaseGLiNER):
                 "end_token_map": [],
                 "word_input_spans": None,
                 "entity_types": [],
+                "label_names": [],
                 "valid_texts": [],
                 "valid_to_orig_idx": [],
                 "num_original": num_original,
             }
-
-        if isinstance(labels, str):
-            entity_types = list(dict.fromkeys([labels]))
-        elif labels and isinstance(labels[0], list):
-            if len(labels) != num_original:
-                raise ValueError(f"Per-text labels must have length {num_original}, got {len(labels)}")
-            all_entity_types = [list(dict.fromkeys(lbls)) for lbls in labels]
-            entity_types = [all_entity_types[i] for i in valid_to_orig_idx]
-        else:
-            entity_types = list(dict.fromkeys(labels))
 
         tokens, start_token_map, end_token_map = self.prepare_inputs(valid_texts)
 
@@ -2556,6 +2628,7 @@ class BaseEncoderGLiNER(BaseGLiNER):
             "end_token_map": end_token_map,
             "word_input_spans": word_input_spans,
             "entity_types": entity_types,
+            "label_names": label_names,
             "valid_texts": valid_texts,
             "valid_to_orig_idx": valid_to_orig_idx,
             "num_original": num_original,
@@ -2566,6 +2639,7 @@ class BaseEncoderGLiNER(BaseGLiNER):
         input_x: List[Dict[str, Any]],
         entity_types: Union[List[str], List[List[str]]],
         collator: Optional[Any] = None,
+        label_names: Optional[Union[List[str], List[List[str]]]] = None,
     ) -> Dict[str, Any]:
         """Collate prepared inputs into a tensor batch.
 
@@ -2573,6 +2647,7 @@ class BaseEncoderGLiNER(BaseGLiNER):
             input_x: List of input dicts from prepare_batch.
             entity_types: Entity type labels.
             collator: Optional pre-created collator instance. If None, creates one.
+            label_names: Optional public names corresponding to model-facing entity prompts.
 
         Returns:
             Collated batch dictionary with tensors ready for the model.
@@ -2588,6 +2663,7 @@ class BaseEncoderGLiNER(BaseGLiNER):
             )
 
         batch = collator(input_x, entity_types=entity_types)
+        _remap_id_to_classes(batch, entity_types, label_names)
         return batch
 
     @torch.inference_mode()
@@ -2730,7 +2806,7 @@ class BaseEncoderGLiNER(BaseGLiNER):
     def inference(
         self,
         texts: Union[str, List[str]],
-        labels: List[str],
+        labels: EntityLabels,
         flat_ner: bool = True,
         threshold: float = 0.5,
         multi_label: bool = False,
@@ -2744,7 +2820,7 @@ class BaseEncoderGLiNER(BaseGLiNER):
 
         Args:
             texts: A list of input texts to predict entities for or a single text string.
-            labels: A list of labels to predict.
+            labels: Shared or per-text entity labels, optionally mapped to descriptions.
             flat_ner: Whether to use flat NER. Defaults to True.
             threshold: Confidence threshold for predictions. Defaults to 0.5.
             multi_label: Whether to allow multiple labels per token. Defaults to False.
@@ -2774,11 +2850,16 @@ class BaseEncoderGLiNER(BaseGLiNER):
         collator = self.create_collator()
 
         def collate_fn(indices):
-            return self.collate_batch(
+            entity_types = _entity_types_for_chunk(prepared["entity_types"], indices)
+            label_names = prepared.get("label_names")
+            label_names = entity_types if label_names is None else _entity_types_for_chunk(label_names, indices)
+            batch = self.collate_batch(
                 [prepared["input_x"][i] for i in indices],
-                _entity_types_for_chunk(prepared["entity_types"], indices),
+                entity_types,
                 collator,
             )
+            _remap_id_to_classes(batch, entity_types, label_names)
+            return batch
 
         loader_batch_size = batch_size
         entity_types = prepared["entity_types"]
@@ -2829,7 +2910,7 @@ class BaseEncoderGLiNER(BaseGLiNER):
     def predict_entities(
         self,
         text: str,
-        labels: List[str],
+        labels: EntityLabels,
         flat_ner: bool = True,
         threshold: float = 0.5,
         multi_label: bool = False,
@@ -2863,7 +2944,7 @@ class BaseEncoderGLiNER(BaseGLiNER):
     def batch_predict_entities(
         self,
         texts: List[str],
-        labels: List[str],
+        labels: EntityLabels,
         flat_ner: bool = True,
         threshold: float = 0.5,
         multi_label: bool = False,
@@ -5172,7 +5253,7 @@ class UniEncoderSpanDecoderGLiNER(BaseEncoderGLiNER):
     def inference(
         self,
         texts: Union[str, List[str]],
-        labels: List[str],
+        labels: EntityLabels,
         flat_ner: bool = True,
         threshold: float = 0.5,
         multi_label: bool = False,
@@ -5214,11 +5295,16 @@ class UniEncoderSpanDecoderGLiNER(BaseEncoderGLiNER):
         collator = self.create_collator()
 
         def collate_fn(indices):
-            return self.collate_batch(
+            entity_types = _entity_types_for_chunk(prepared["entity_types"], indices)
+            label_names = prepared.get("label_names")
+            label_names = entity_types if label_names is None else _entity_types_for_chunk(label_names, indices)
+            batch = self.collate_batch(
                 [prepared["input_x"][i] for i in indices],
-                _entity_types_for_chunk(prepared["entity_types"], indices),
+                entity_types,
                 collator,
             )
+            _remap_id_to_classes(batch, entity_types, label_names)
+            return batch
 
         data_loader = torch.utils.data.DataLoader(
             list(range(len(prepared["input_x"]))),
@@ -5256,7 +5342,7 @@ class UniEncoderSpanDecoderGLiNER(BaseEncoderGLiNER):
     def predict_entities(
         self,
         text: str,
-        labels: List[str],
+        labels: EntityLabels,
         flat_ner: bool = True,
         threshold: float = 0.5,
         multi_label: bool = False,
@@ -5377,7 +5463,7 @@ class UniEncoderSpanRelexGLiNER(BaseEncoderGLiNER):
     def prepare_batch(
         self,
         texts: Union[str, List[str]],
-        labels: Union[str, List[str], List[List[str]]],
+        labels: EntityLabels,
         input_spans: Optional[List[List[Dict]]] = None,
         relations: Optional[Union[str, List[str], List[List[str]]]] = None,
         **kwargs,
@@ -5386,7 +5472,7 @@ class UniEncoderSpanRelexGLiNER(BaseEncoderGLiNER):
 
         Args:
             texts: Single text string or list of texts.
-            labels: Entity labels - string, list of strings, or per-text label lists.
+            labels: Shared or per-text entity labels, optionally mapped to descriptions.
             input_spans: Optional pre-defined spans to classify (character positions).
             relations: Relation type labels - string, list of strings, or per-text label lists.
             **kwargs: Additional keyword arguments passed to the parent prepare_batch.
@@ -5420,6 +5506,7 @@ class UniEncoderSpanRelexGLiNER(BaseEncoderGLiNER):
         entity_types: Union[List[str], List[List[str]]],
         collator: Optional[Any] = None,
         relation_types: Optional[Union[List[str], List[List[str]]]] = None,
+        label_names: Optional[Union[List[str], List[List[str]]]] = None,
     ) -> Dict[str, Any]:
         """Collate prepared inputs into a tensor batch with relation types.
 
@@ -5428,6 +5515,7 @@ class UniEncoderSpanRelexGLiNER(BaseEncoderGLiNER):
             entity_types: Entity type labels.
             collator: Optional pre-created collator instance.
             relation_types: Relation type labels (list or per-text lists).
+            label_names: Optional public names corresponding to model-facing entity prompts.
 
         Returns:
             Collated batch dictionary with tensors ready for the model.
@@ -5439,6 +5527,7 @@ class UniEncoderSpanRelexGLiNER(BaseEncoderGLiNER):
             relation_types = []
 
         batch = collator(input_x, entity_types=entity_types, relation_types=relation_types)
+        _remap_id_to_classes(batch, entity_types, label_names)
         return batch
 
     def create_collator(self) -> Any:
@@ -5712,7 +5801,7 @@ class UniEncoderSpanRelexGLiNER(BaseEncoderGLiNER):
     def inference(
         self,
         texts: Union[str, List[str]],
-        labels: Union[str, List[str], List[List[str]]],
+        labels: EntityLabels,
         relations: Union[str, List[str], List[List[str]]] = [],
         flat_ner: bool = True,
         threshold: float = 0.5,
@@ -5729,7 +5818,7 @@ class UniEncoderSpanRelexGLiNER(BaseEncoderGLiNER):
 
         Args:
             texts: Input texts (str or List[str]).
-            labels: Entity type labels - string, list of strings, or per-text label lists.
+            labels: Shared or per-text entity labels, optionally mapped to descriptions.
             relations: Relation type labels - string, list of strings, or per-text label lists.
             flat_ner: Whether to use flat NER (no nested entities).
             threshold: Confidence threshold for entities.
@@ -5764,12 +5853,17 @@ class UniEncoderSpanRelexGLiNER(BaseEncoderGLiNER):
         collator = self.create_collator()
 
         def collate_fn(indices):
-            return self.collate_batch(
+            entity_types = _entity_types_for_chunk(prepared["entity_types"], indices)
+            label_names = prepared.get("label_names")
+            label_names = entity_types if label_names is None else _entity_types_for_chunk(label_names, indices)
+            batch = self.collate_batch(
                 [prepared["input_x"][i] for i in indices],
-                _entity_types_for_chunk(prepared["entity_types"], indices),
+                entity_types,
                 collator,
                 _entity_types_for_chunk(prepared["relation_types"], indices),
             )
+            _remap_id_to_classes(batch, entity_types, label_names)
+            return batch
 
         data_loader = torch.utils.data.DataLoader(
             list(range(len(prepared["input_x"]))),
@@ -5819,7 +5913,7 @@ class UniEncoderSpanRelexGLiNER(BaseEncoderGLiNER):
     def predict_entities(
         self,
         text: str,
-        labels: List[str],
+        labels: EntityLabels,
         relations: List[str] = [],
         flat_ner: bool = True,
         threshold: float = 0.5,
@@ -5860,7 +5954,7 @@ class UniEncoderSpanRelexGLiNER(BaseEncoderGLiNER):
     def predict_relations(
         self,
         text: str,
-        labels: List[str],
+        labels: EntityLabels,
         relations: List[str],
         flat_ner: bool = True,
         threshold: float = 0.5,

--- a/gliner/modeling/base.py
+++ b/gliner/modeling/base.py
@@ -473,6 +473,7 @@ class UniEncoderSpanModel(BaseUniEncoderModel):
         span_idx: Optional[torch.LongTensor] = None,
         span_mask: Optional[torch.LongTensor] = None,
         labels: Optional[torch.FloatTensor] = None,
+        return_embeddings: bool = False,
         **kwargs: Any,
     ) -> GLiNERBaseOutput:
         """Forward pass through the span-based model.
@@ -489,6 +490,7 @@ class UniEncoderSpanModel(BaseUniEncoderModel):
             span_idx: Span indices of shape (B, L*K, 2).
             span_mask: Mask for valid spans of shape (B, L, K).
             labels: Ground truth labels of shape (B, L, K, C).
+            return_embeddings: Whether to include span representations in the output.
             **kwargs: Additional arguments.
 
         Returns:
@@ -537,6 +539,7 @@ class UniEncoderSpanModel(BaseUniEncoderModel):
             prompts_embedding_mask=prompts_embedding_mask,
             words_embedding=words_embedding,
             mask=mask,
+            span_embeddings=span_rep if return_embeddings else None,
         )
         return output
 
@@ -959,6 +962,7 @@ class StreamingSpanModel(UniEncoderSpanModel):
         span_idx: Optional[torch.LongTensor] = None,
         span_mask: Optional[torch.LongTensor] = None,
         labels: Optional[torch.FloatTensor] = None,
+        return_embeddings: bool = False,
         **kwargs: Any,
     ) -> GLiNERStreamingSpanOutput:
         """Forward pass through the span-based model.
@@ -981,6 +985,7 @@ class StreamingSpanModel(UniEncoderSpanModel):
             span_idx: Span indices of shape (B, L*K, 2).
             span_mask: Mask for valid spans of shape (B, L, K).
             labels: Ground truth labels of shape (B, L, K, C).
+            return_embeddings: Whether to include span representations in the output.
             **kwargs: Additional arguments.
 
         Returns:
@@ -1072,6 +1077,7 @@ class StreamingSpanModel(UniEncoderSpanModel):
             mask=mask,
             span_idx=flat_span_idx,
             span_mask=flat_span_mask,
+            span_embeddings=span_rep if return_embeddings else None,
             past_key_values=representations.past_key_values,
             past_word_embeddings=representations.past_word_embeddings,
             past_word_mask=representations.past_word_mask,
@@ -1498,6 +1504,7 @@ class BiEncoderSpanModel(BaseBiEncoderModel):
         span_mask: Optional[torch.LongTensor] = None,
         labels: Optional[torch.FloatTensor] = None,
         labels_gather_indices: Optional[torch.LongTensor] = None,
+        return_embeddings: bool = False,
         **kwargs: Any,
     ) -> GLiNERBaseOutput:
         """Forward pass through the bi-encoder span model.
@@ -1518,6 +1525,7 @@ class BiEncoderSpanModel(BaseBiEncoderModel):
             span_mask: Mask for valid spans of shape (B, L, K).
             labels: Ground truth labels of shape (B, L, K, C).
             labels_gather_indices: Per-row indices into the shared label embeddings.
+            return_embeddings: Whether to include span representations in the output.
             **kwargs: Additional arguments.
 
         Returns:
@@ -1576,6 +1584,7 @@ class BiEncoderSpanModel(BaseBiEncoderModel):
             prompts_embedding_mask=prompts_embedding_mask,
             words_embedding=words_embedding,
             mask=mask,
+            span_embeddings=span_rep if return_embeddings else None,
         )
         return output
 
@@ -2116,6 +2125,7 @@ class UniEncoderSpanDecoderModel(UniEncoderSpanModel):
         labels: Optional[torch.FloatTensor] = None,
         decoder_labels: Optional[torch.FloatTensor] = None,
         threshold: Optional[float] = 0.5,
+        return_embeddings: bool = False,
         **kwargs: Any,
     ) -> GLiNERDecoderOutput:
         """Forward pass through the span-decoder model.
@@ -2139,6 +2149,7 @@ class UniEncoderSpanDecoderModel(UniEncoderSpanModel):
             labels: Ground truth span labels of shape (B, L, K, C).
             decoder_labels: Ground truth decoder labels of shape (M, L).
             threshold: Confidence threshold for span selection.
+            return_embeddings: Whether to include span representations in the output.
             **kwargs: Additional arguments.
 
         Returns:
@@ -2218,6 +2229,7 @@ class UniEncoderSpanDecoderModel(UniEncoderSpanModel):
             decoder_span_idx=decoder_span_idx,
             words_embedding=words_embedding,
             mask=mask,
+            span_embeddings=span_rep if return_embeddings else None,
         )
         return output
 
@@ -2382,7 +2394,7 @@ class UniEncoderTokenDecoderModel(UniEncoderTokenModel, UniEncoderSpanDecoderMod
         else:
             # During inference: use predicted scores
             span_scores = torch.sigmoid(span_logits).max(-1).values  # (B, S)
-            keep = (span_scores > 0.5) & span_mask.bool
+            keep = (span_scores > 0.5) & span_mask.bool()
 
         if top_k:
             sel_scores = span_scores.masked_fill(~keep, -1.0)
@@ -2826,6 +2838,7 @@ class UniEncoderSpanRelexModel(UniEncoderSpanModel):
         span_mask: Optional[torch.Tensor] = None,
         labels: Optional[torch.Tensor] = None,
         threshold: float = 0.5,
+        return_embeddings: bool = False,
     ):
         span_idx = span_idx * span_mask.unsqueeze(-1).long()
         span_rep = self.span_rep_layer(words_embeddings, span_idx)
@@ -2842,7 +2855,10 @@ class UniEncoderSpanRelexModel(UniEncoderSpanModel):
             )
         else:
             target_span_rep, target_span_mask, entity_spans = None, None, None
-        return scores, target_span_rep, target_span_mask, entity_spans
+        output = (scores, target_span_rep, target_span_mask, entity_spans)
+        if return_embeddings:
+            return (*output, span_rep)
+        return output
 
     def forward(
         self,
@@ -2861,6 +2877,7 @@ class UniEncoderSpanRelexModel(UniEncoderSpanModel):
         rel_matrix: Optional[torch.FloatTensor] = None,
         threshold: Optional[float] = 0.5,
         adjacency_threshold: Optional[float] = 0.5,
+        return_embeddings: bool = False,
         **kwargs: Any,
     ) -> GLiNERRelexOutput:
         """Forward pass through the relation extraction model.
@@ -2881,6 +2898,7 @@ class UniEncoderSpanRelexModel(UniEncoderSpanModel):
             rel_matrix: Ground truth relation labels of shape (B, N, C_rel).
             threshold: Confidence threshold for entity selection.
             adjacency_threshold: Threshold for relation adjacency.
+            return_embeddings: Whether to include entity and relation representations in the output.
             **kwargs: Additional arguments.
 
         Returns:
@@ -2947,12 +2965,25 @@ class UniEncoderSpanRelexModel(UniEncoderSpanModel):
         prompts_embedding = self.prompt_rep_layer(prompts_embedding)
         batch_size, _, embed_dim = prompts_embedding.shape
 
-        scores, target_span_rep, target_span_mask, entity_spans = self.represent_spans(
-            words_embedding, mask, prompts_embedding, span_idx, span_mask, labels, threshold
+        span_outputs = self.represent_spans(
+            words_embedding,
+            mask,
+            prompts_embedding,
+            span_idx,
+            span_mask,
+            labels,
+            threshold,
+            return_embeddings=return_embeddings,
         )
+        if return_embeddings:
+            scores, target_span_rep, target_span_mask, entity_spans, span_embeddings = span_outputs
+        else:
+            scores, target_span_rep, target_span_mask, entity_spans = span_outputs
+            span_embeddings = None
 
         pair_idx, pair_mask, pair_scores = None, None, None
         rel_prompts_embedding, rel_prompts_embedding_mask = None, None
+        relation_embeddings = relation_head_embeddings = relation_tail_embeddings = None
         pred_adj_matrix = None
 
         has_relex = (
@@ -2999,6 +3030,8 @@ class UniEncoderSpanRelexModel(UniEncoderSpanModel):
                 pair_rep = torch.cat((head_rep_selected, tail_rep_selected), dim=-1)
                 pair_rep = self.pair_rep_layer(pair_rep)
                 pair_scores = torch.einsum("BND,BCD->BNC", pair_rep, rel_prompts_embedding)
+                if return_embeddings:
+                    relation_embeddings = pair_rep
 
             elif hasattr(self, "triples_score_layer"):
                 h = head_rep_selected.unsqueeze(2).expand(B, N, C_rel, D)
@@ -3011,6 +3044,9 @@ class UniEncoderSpanRelexModel(UniEncoderSpanModel):
 
                 triple_scores_flat = self.triples_score_layer(h_flat, r_flat, t_flat)
                 pair_scores = triple_scores_flat.view(B, N, C_rel)
+                if return_embeddings:
+                    relation_head_embeddings = head_rep_selected
+                    relation_tail_embeddings = tail_rep_selected
 
         loss = None
         if labels is not None:
@@ -3083,6 +3119,10 @@ class UniEncoderSpanRelexModel(UniEncoderSpanModel):
             rel_prompts_embedding=rel_prompts_embedding,
             rel_prompts_embedding_mask=rel_prompts_embedding_mask,
             entity_spans=None if is_training else entity_spans,
+            span_embeddings=span_embeddings,
+            relation_embeddings=None if is_training else relation_embeddings,
+            relation_head_embeddings=None if is_training else relation_head_embeddings,
+            relation_tail_embeddings=None if is_training else relation_tail_embeddings,
         )
         return output
 
@@ -3298,6 +3338,7 @@ class UniEncoderTokenRelexModel(UniEncoderSpanRelexModel):
         span_mask: Optional[torch.Tensor] = None,
         labels: Optional[torch.Tensor] = None,
         threshold: float = 0.5,
+        return_embeddings: bool = False,
     ):
         scores = self.scorer(words_embeddings, prompts_embeddings)
 
@@ -3306,5 +3347,9 @@ class UniEncoderTokenRelexModel(UniEncoderSpanRelexModel):
             span_idx = span_idx * span_mask.unsqueeze(-1).long()
         target_span_rep = self.span_rep_layer(words_embeddings, span_idx)
 
-        # span_idx directly corresponds to target_span_rep positions
-        return scores, target_span_rep, span_mask, span_idx
+        # span_idx directly corresponds to target_span_rep positions. Token-level
+        # public span embeddings are pooled from words_embeddings by the caller.
+        output = (scores, target_span_rep, span_mask, span_idx)
+        if return_embeddings:
+            return (*output, None)
+        return output

--- a/gliner/modeling/outputs.py
+++ b/gliner/modeling/outputs.py
@@ -1,5 +1,5 @@
 from typing import Any, Optional
-from dataclasses import dataclass
+from dataclasses import field, dataclass
 
 import torch
 from transformers.utils import ModelOutput
@@ -27,6 +27,9 @@ class GLiNERBaseOutput(ModelOutput):
             words/tokens. Shape: [batch_size, seq_len, hidden_size].
         mask (Optional[torch.LongTensor]): Attention mask for input tokens.
             Shape: [batch_size, seq_len].
+        span_embeddings (Optional[torch.FloatTensor]): Native span representations
+            used by span-based scorers. Shape: [batch_size, seq_len, max_width, hidden_size]
+            or [batch_size, num_spans, hidden_size].
     """
 
     loss: Optional[torch.FloatTensor] = None
@@ -38,6 +41,7 @@ class GLiNERBaseOutput(ModelOutput):
     span_idx: Optional[torch.LongTensor] = None
     span_mask: Optional[torch.Tensor] = None
     span_logits: Optional[torch.FloatTensor] = None
+    span_embeddings: Optional[torch.FloatTensor] = field(default=None, kw_only=True)
 
 
 @dataclass
@@ -122,6 +126,15 @@ class GLiNERRelexOutput(GLiNERBaseOutput):
             relation type prompts/labels. Shape: [batch_size, num_relation_types, hidden_size].
         rel_prompts_embedding_mask (Optional[torch.LongTensor]): Attention mask
             for relation prompt embeddings. Shape: [batch_size, num_relation_types].
+        relation_embeddings (Optional[torch.FloatTensor]): Projected entity-pair
+            representations used by pair-based relation scorers. Shape:
+            [batch_size, num_relations, hidden_size].
+        relation_head_embeddings (Optional[torch.FloatTensor]): Selected head
+            representations used by triple-based relation scorers. Shape:
+            [batch_size, num_relations, hidden_size].
+        relation_tail_embeddings (Optional[torch.FloatTensor]): Selected tail
+            representations used by triple-based relation scorers. Shape:
+            [batch_size, num_relations, hidden_size].
     """
 
     rel_idx: Optional[torch.LongTensor] = None
@@ -130,3 +143,6 @@ class GLiNERRelexOutput(GLiNERBaseOutput):
     entity_spans: Optional[torch.LongTensor] = None
     rel_prompts_embedding: Optional[torch.FloatTensor] = None
     rel_prompts_embedding_mask: Optional[torch.LongTensor] = None
+    relation_embeddings: Optional[torch.FloatTensor] = field(default=None, kw_only=True)
+    relation_head_embeddings: Optional[torch.FloatTensor] = field(default=None, kw_only=True)
+    relation_tail_embeddings: Optional[torch.FloatTensor] = field(default=None, kw_only=True)

--- a/gliner/serve/client.py
+++ b/gliner/serve/client.py
@@ -5,6 +5,18 @@ from typing import Any, Dict, List, Union, Optional
 DEFAULT_BASE_URL = "http://localhost:8000"
 DEFAULT_ROUTE_PREFIX = "/gliner"
 
+LabelSet = Union[List[str], Dict[str, str]]
+Labels = Union[LabelSet, List[LabelSet]]
+
+
+def _labels_for_texts(labels: Labels, num_texts: int) -> List[LabelSet]:
+    """Return one label set per text while preserving shared label sets."""
+    if isinstance(labels, list) and labels and isinstance(labels[0], (list, dict)):
+        if len(labels) != num_texts:
+            raise ValueError(f"Per-text labels must have length {num_texts}, got {len(labels)}")
+        return labels
+    return [labels] * num_texts
+
 
 class GLiNERClientError(RuntimeError):
     """Raised when the GLiNER server returns an error or is unreachable."""
@@ -46,7 +58,7 @@ class GLiNERClient:
     def _build_payload(
         self,
         text: str,
-        labels: List[str],
+        labels: LabelSet,
         relations: Optional[List[str]],
         threshold: Optional[float],
         relation_threshold: Optional[float],
@@ -92,7 +104,7 @@ class GLiNERClient:
     def predict(
         self,
         text: Union[str, List[str]],
-        labels: List[str],
+        labels: Labels,
         relations: Optional[List[str]] = None,
         threshold: Optional[float] = None,
         relation_threshold: Optional[float] = None,
@@ -103,13 +115,14 @@ class GLiNERClient:
         """Blocking prediction. ``str`` in -> ``dict`` out; ``list`` in -> ``list`` out."""
         single = isinstance(text, str)
         items = [text] if single else list(text)
+        labels_list = _labels_for_texts(labels, len(items))
 
         payloads = [
             self._build_payload(
-                t, labels, relations, threshold, relation_threshold,
+                t, label_set, relations, threshold, relation_threshold,
                 flat_ner, multi_label, adapter_id,
             )
-            for t in items
+            for t, label_set in zip(items, labels_list)
         ]
 
         if len(payloads) == 1:
@@ -126,7 +139,7 @@ class GLiNERClient:
     async def predict_async(
         self,
         text: Union[str, List[str]],
-        labels: List[str],
+        labels: Labels,
         relations: Optional[List[str]] = None,
         threshold: Optional[float] = None,
         relation_threshold: Optional[float] = None,
@@ -139,13 +152,14 @@ class GLiNERClient:
 
         single = isinstance(text, str)
         items = [text] if single else list(text)
+        labels_list = _labels_for_texts(labels, len(items))
 
         payloads = [
             self._build_payload(
-                t, labels, relations, threshold, relation_threshold,
+                t, label_set, relations, threshold, relation_threshold,
                 flat_ner, multi_label, adapter_id,
             )
-            for t in items
+            for t, label_set in zip(items, labels_list)
         ]
 
         results = await asyncio.gather(

--- a/gliner/serve/server.py
+++ b/gliner/serve/server.py
@@ -15,6 +15,9 @@ from .memory import GLiNERMemoryEstimator
 
 logger = logging.getLogger(__name__)
 
+LabelSet = Union[List[str], Dict[str, str]]
+Labels = Union[LabelSet, List[LabelSet]]
+
 
 def _min_batch_value(value):
     if isinstance(value, list):
@@ -29,6 +32,20 @@ def _normalize_relation_lists(relations):
         normalized = [item or [] for item in relations]
         return None if all(not item for item in normalized) else normalized
     return relations
+
+
+def _labels_for_texts(labels: Labels, num_texts: int) -> List[LabelSet]:
+    """Return one label set per text while preserving shared label sets."""
+    if isinstance(labels, list) and labels and isinstance(labels[0], (list, dict)):
+        if len(labels) != num_texts:
+            raise ValueError(f"Per-text labels must have length {num_texts}, got {len(labels)}")
+        return labels
+    return [labels] * num_texts
+
+
+def _label_word_count(labels: LabelSet) -> int:
+    prompts = labels.values() if isinstance(labels, dict) else labels
+    return sum(len(label.split()) for label in prompts)
 
 
 class GLiNERServer:
@@ -313,7 +330,7 @@ class GLiNERServer:
     def observed_seq_len(
         self,
         texts: List[str],
-        labels: Optional[List[str] | List[List[str]]] = None,
+        labels: Optional[Labels] = None,
         relations: Optional[List[str] | List[List[str] | None]] = None,
     ) -> int:
         """Total input word count: longest text + all label/relation words.
@@ -325,10 +342,10 @@ class GLiNERServer:
         max_text_words = max((len(t.split()) for t in texts if t.strip()), default=0)
         prompt_words = 0
         if labels:
-            if isinstance(labels[0], list):
-                prompt_words += max(sum(len(label.split()) for label in label_set) for label_set in labels)
+            if isinstance(labels, list) and labels and isinstance(labels[0], (list, dict)):
+                prompt_words += max(_label_word_count(label_set) for label_set in labels)
             else:
-                prompt_words += sum(len(label.split()) for label in labels)
+                prompt_words += _label_word_count(labels)
         if relations:
             normalized_relations = _normalize_relation_lists(relations)
             if normalized_relations:
@@ -342,12 +359,14 @@ class GLiNERServer:
         total = max_text_words + prompt_words
         return min(max(total, self.config.calibration_min_seq_len), self.config.max_model_len)
 
-    def _filter_labels(self, labels: List[str] | List[List[str]]) -> List[str] | List[List[str]]:
+    def _filter_labels(self, labels: Labels) -> Labels:
         """Filter labels based on max_labels config."""
-        if labels and isinstance(labels[0], list):
+        if isinstance(labels, list) and labels and isinstance(labels[0], (list, dict)):
             return [self._filter_labels(label_set) for label_set in labels]
         if self.config.max_labels > 0 and len(labels) > self.config.max_labels:
             logger.warning("Truncating labels from %d to %d", len(labels), self.config.max_labels)
+            if isinstance(labels, dict):
+                return dict(list(labels.items())[: self.config.max_labels])
             return labels[: self.config.max_labels]
         return labels
 
@@ -355,7 +374,7 @@ class GLiNERServer:
     def _run_batch_internal(
         self,
         texts: List[str],
-        labels: List[str] | List[List[str]],
+        labels: Labels,
         relations: Optional[List[str] | List[List[str] | None]] = None,
         threshold: float | List[float] = 0.5,
         relation_threshold: float | List[float] = 0.5,
@@ -383,6 +402,38 @@ class GLiNERServer:
             For NER models: List of entity lists.
             For relex models: Tuple of (entities, relations) lists.
         """
+        per_text_labels = isinstance(labels, list) and bool(labels) and isinstance(labels[0], (list, dict))
+        if getattr(self.model, "is_runtime_model", False) and len(texts) > 1 and per_text_labels:
+            if len(labels) != len(texts):
+                raise ValueError(f"Per-text labels must have length {len(texts)}, got {len(labels)}")
+
+            entity_results = []
+            relation_results = []
+            per_text_relations = bool(relations) and isinstance(relations[0], (list, type(None)))
+            for index, text in enumerate(texts):
+                result = self._run_batch_internal(
+                    [text],
+                    labels[index],
+                    relations=relations[index] if per_text_relations else relations,
+                    threshold=threshold[index] if isinstance(threshold, list) else threshold,
+                    relation_threshold=(
+                        relation_threshold[index] if isinstance(relation_threshold, list) else relation_threshold
+                    ),
+                    flat_ner=flat_ner[index] if isinstance(flat_ner, list) else flat_ner,
+                    multi_label=multi_label[index] if isinstance(multi_label, list) else multi_label,
+                    adapter_ids=adapter_ids[index] if isinstance(adapter_ids, list) else adapter_ids,
+                )
+                if self._supports_relations:
+                    entities, found_relations = result
+                    entity_results.extend(entities)
+                    relation_results.extend(found_relations)
+                else:
+                    entity_results.extend(result)
+
+            if self._supports_relations:
+                return entity_results, relation_results
+            return entity_results
+
         if self._supports_relations:
             return self._run_batch_relex(
                 texts,
@@ -400,7 +451,7 @@ class GLiNERServer:
     def _run_batch_ner(
         self,
         texts: List[str],
-        labels: List[str] | List[List[str]],
+        labels: Labels,
         threshold: float | List[float],
         flat_ner: bool | List[bool],
         multi_label: bool | List[bool],
@@ -418,6 +469,7 @@ class GLiNERServer:
             prepared["input_x"],
             prepared["entity_types"],
             self.collator,
+            label_names=prepared["label_names"],
         )
 
         run_kwargs: Dict[str, Any] = {}
@@ -454,7 +506,7 @@ class GLiNERServer:
     def _run_batch_relex(
         self,
         texts: List[str],
-        labels: List[str] | List[List[str]],
+        labels: Labels,
         relations: Optional[List[str] | List[List[str] | None]],
         threshold: float | List[float],
         relation_threshold: float | List[float],
@@ -477,6 +529,7 @@ class GLiNERServer:
             prepared["entity_types"],
             self.collator,
             relation_types=prepared.get("relation_types", []),
+            label_names=prepared["label_names"],
         )
 
         run_kwargs: Dict[str, Any] = {}
@@ -525,7 +578,7 @@ class GLiNERServer:
     def predict(
         self,
         texts: Union[str, List[str]],
-        labels: List[str],
+        labels: Labels,
         relations: Optional[List[str]] = None,
         threshold: Optional[float] = None,
         relation_threshold: Optional[float] = None,
@@ -537,7 +590,7 @@ class GLiNERServer:
 
         Args:
             texts: Input text(s) to process.
-            labels: Entity type labels to extract.
+            labels: Entity labels shared by all texts, or one label set per text.
             relations: Relation type labels (only for relex models).
             threshold: Confidence threshold for entities.
             relation_threshold: Confidence threshold for relations.
@@ -623,7 +676,7 @@ def _build_deployment(config: GLiNERServeConfig):
         async def _infer_batch(
             self,
             texts: List[str],
-            labels_list: List[List[str]],
+            labels_list: List[LabelSet],
             relations_list: List[Optional[List[str]]],
             thresholds: List[float],
             relation_thresholds: List[float],
@@ -679,7 +732,7 @@ def _build_deployment(config: GLiNERServeConfig):
         async def predict(
             self,
             text: str,
-            labels: List[str],
+            labels: LabelSet,
             relations: Optional[List[str]] = None,
             threshold: Optional[float] = None,
             relation_threshold: Optional[float] = None,
@@ -731,7 +784,7 @@ def _build_deployment(config: GLiNERServeConfig):
                 )
             except KeyError as exc:
                 return JSONResponse({"error": str(exc)}, status_code=404)
-            except ValueError as exc:
+            except (TypeError, ValueError) as exc:
                 return JSONResponse({"error": str(exc)}, status_code=400)
 
     return GLiNERDeployment.bind(config)
@@ -859,7 +912,7 @@ class GLiNERFactory:
     def predict(
         self,
         texts: Union[str, List[str]],
-        labels: List[str],
+        labels: Labels,
         relations: Optional[List[str]] = None,
         threshold: Optional[float] = None,
         relation_threshold: Optional[float] = None,
@@ -870,11 +923,12 @@ class GLiNERFactory:
         """Blocking prediction. Returns a dict for ``str`` input, list for list input."""
         single = isinstance(texts, str)
         items = [texts] if single else list(texts)
+        labels_list = _labels_for_texts(labels, len(items))
 
         refs = [
             self._handle.predict.remote(
                 t,
-                labels,
+                label_set,
                 relations,
                 threshold,
                 relation_threshold,
@@ -882,7 +936,7 @@ class GLiNERFactory:
                 multi_label,
                 adapter_id,
             )
-            for t in items
+            for t, label_set in zip(items, labels_list)
         ]
         results = [ref.result() for ref in refs]
         return results[0] if single else results
@@ -890,7 +944,7 @@ class GLiNERFactory:
     async def predict_async(
         self,
         texts: Union[str, List[str]],
-        labels: List[str],
+        labels: Labels,
         relations: Optional[List[str]] = None,
         threshold: Optional[float] = None,
         relation_threshold: Optional[float] = None,
@@ -903,11 +957,12 @@ class GLiNERFactory:
 
         single = isinstance(texts, str)
         items = [texts] if single else list(texts)
+        labels_list = _labels_for_texts(labels, len(items))
 
         refs = [
             self._handle.predict.remote(
                 t,
-                labels,
+                label_set,
                 relations,
                 threshold,
                 relation_threshold,
@@ -915,7 +970,7 @@ class GLiNERFactory:
                 multi_label,
                 adapter_id,
             )
-            for t in items
+            for t, label_set in zip(items, labels_list)
         ]
         results = list(await asyncio.gather(*refs))
         return results[0] if single else results

--- a/tests/test_label_descriptions.py
+++ b/tests/test_label_descriptions.py
@@ -1,0 +1,259 @@
+from types import SimpleNamespace
+
+import torch
+import pytest
+
+from gliner.model import BaseEncoderGLiNER, UniEncoderSpanRelexGLiNER
+from gliner.decoding.decoder import Span
+
+
+class _WordsSplitter:
+    def __call__(self, text):
+        cursor = 0
+        for token in text.split():
+            start = text.index(token, cursor)
+            end = start + len(token)
+            cursor = end
+            yield token, start, end
+
+
+class _RecordingCollator:
+    """Small stand-in that exposes exactly which strings reach the processor."""
+
+    def __init__(self):
+        self.entity_types = []
+
+    def __call__(self, input_x, entity_types, relation_types=None):
+        self.entity_types.append(entity_types)
+
+        if entity_types and isinstance(entity_types[0], list):
+            id_to_classes = [dict(enumerate(label_set, start=1)) for label_set in entity_types]
+        else:
+            id_to_classes = dict(enumerate(entity_types, start=1))
+
+        batch = {
+            "tokens": [item["tokenized_text"] for item in input_x],
+            "id_to_classes": id_to_classes,
+        }
+        if relation_types is not None:
+            batch["rel_id_to_classes"] = dict(enumerate(relation_types, start=1))
+        return batch
+
+
+def _minimal_encoder_model():
+    model = BaseEncoderGLiNER.__new__(BaseEncoderGLiNER)
+    torch.nn.Module.__init__(model)
+    model.data_processor = SimpleNamespace(words_splitter=_WordsSplitter())
+    model._inference_packing_config = None
+    return model
+
+
+def _inference_model():
+    model = _minimal_encoder_model()
+    collator = _RecordingCollator()
+    model.create_collator = lambda: collator
+    model.run_batch = lambda *args, **kwargs: object()
+
+    def decode_batch(model_output, batch, **kwargs):
+        mappings = batch["id_to_classes"]
+        if not isinstance(mappings, list):
+            mappings = [mappings for _ in batch["tokens"]]
+
+        return [
+            [
+                Span(
+                    start=0,
+                    end=0,
+                    entity_type=mapping[1],
+                    score=0.9,
+                    class_probs={mapping[1]: 0.9},
+                )
+            ]
+            for mapping in mappings
+        ]
+
+    model.decode_batch = decode_batch
+    return model, collator
+
+
+def test_prepare_batch_splits_dictionary_prompts_from_public_names():
+    model = _minimal_encoder_model()
+
+    prepared = model.prepare_batch(
+        ["John works at Acme"],
+        {
+            "person": "A human individual",
+            "organization": "A company or institution",
+        },
+    )
+
+    assert prepared["entity_types"] == ["A human individual", "A company or institution"]
+    assert prepared["label_names"] == ["person", "organization"]
+
+
+def test_prepare_batch_aligns_per_text_dictionaries_after_empty_text_filtering():
+    model = _minimal_encoder_model()
+
+    prepared = model.prepare_batch(
+        ["", "Paris is sunny", "Acme hired Alice"],
+        [
+            {"wrong": "Must be removed with the empty text"},
+            {"location": "A geographical place"},
+            {
+                "organization": "A company or institution",
+                "person": "A human individual",
+            },
+        ],
+    )
+
+    assert prepared["valid_to_orig_idx"] == [1, 2]
+    assert prepared["entity_types"] == [
+        ["A geographical place"],
+        ["A company or institution", "A human individual"],
+    ]
+    assert prepared["label_names"] == [
+        ["location"],
+        ["organization", "person"],
+    ]
+
+
+def test_prepare_batch_validates_per_text_dictionary_count():
+    model = _minimal_encoder_model()
+
+    with pytest.raises(ValueError, match="Per-text labels must have length 2"):
+        model.prepare_batch(["one", "two"], [{"person": "A human individual"}])
+
+
+@pytest.mark.parametrize(
+    "labels",
+    [
+        {1: "A human individual"},
+        {"person": 1},
+        [{"person": "A human individual"}, {"location": 2}],
+    ],
+)
+def test_prepare_batch_rejects_non_string_dictionary_entries(labels):
+    model = _minimal_encoder_model()
+
+    with pytest.raises(TypeError, match="string keys and values"):
+        model.prepare_batch(["one", "two"], labels)
+
+
+def test_prepare_batch_rejects_duplicate_descriptions():
+    model = _minimal_encoder_model()
+
+    with pytest.raises(ValueError, match="descriptions must be unique"):
+        model.prepare_batch(
+            ["Alice"],
+            {
+                "person": "A named thing",
+                "organization": "A named thing",
+            },
+        )
+
+
+def test_prepare_batch_rejects_descriptions_with_precomputed_prompts():
+    model = _minimal_encoder_model()
+    model.config = SimpleNamespace(precomputed_prompts_mode=True)
+
+    with pytest.raises(ValueError, match="precomputed prompt embeddings"):
+        model.prepare_batch(["Alice"], {"person": "A human individual"})
+
+
+@pytest.mark.parametrize(
+    ("labels", "expected_prompts", "expected_names"),
+    [
+        (
+            {"person": "A human individual", "organization": "A company or institution"},
+            ["A human individual", "A company or institution"],
+            {1: "person", 2: "organization"},
+        ),
+        (
+            [
+                {"person": "A human individual"},
+                {"location": "A geographical place"},
+            ],
+            [["A human individual"], ["A geographical place"]],
+            [{1: "person"}, {1: "location"}],
+        ),
+    ],
+)
+def test_collate_batch_encodes_descriptions_and_decodes_public_names(labels, expected_prompts, expected_names):
+    model = _minimal_encoder_model()
+    prepared = model.prepare_batch(["Alice", "Paris"], labels)
+    collator = _RecordingCollator()
+
+    batch = model.collate_batch(
+        prepared["input_x"],
+        prepared["entity_types"],
+        collator,
+        label_names=prepared["label_names"],
+    )
+
+    assert collator.entity_types == [expected_prompts]
+    assert batch["id_to_classes"] == expected_names
+
+
+def test_relex_collate_encodes_descriptions_and_keeps_public_entity_names():
+    model = UniEncoderSpanRelexGLiNER.__new__(UniEncoderSpanRelexGLiNER)
+    torch.nn.Module.__init__(model)
+    model.data_processor = SimpleNamespace(words_splitter=_WordsSplitter())
+    prepared = model.prepare_batch(
+        ["Alice works at Acme"],
+        {"person": "A human individual", "organization": "A company"},
+        relations=["works for"],
+    )
+    collator = _RecordingCollator()
+
+    batch = model.collate_batch(
+        prepared["input_x"],
+        prepared["entity_types"],
+        collator,
+        relation_types=prepared["relation_types"],
+        label_names=prepared["label_names"],
+    )
+
+    assert collator.entity_types == [["A human individual", "A company"]]
+    assert batch["id_to_classes"] == {1: "person", 2: "organization"}
+    assert batch["rel_id_to_classes"] == {1: "works for"}
+
+
+@pytest.mark.parametrize(
+    ("labels", "expected_prompts", "expected_output_names"),
+    [
+        (
+            {"person": "A human individual", "organization": "A company or institution"},
+            [
+                ["A human individual", "A company or institution"],
+                ["A human individual", "A company or institution"],
+            ],
+            ["person", "person"],
+        ),
+        (
+            [
+                {"person": "A human individual"},
+                {"location": "A geographical place"},
+            ],
+            [[["A human individual"]], [["A geographical place"]]],
+            ["person", "location"],
+        ),
+        (
+            ["person", "organization"],
+            [["person", "organization"], ["person", "organization"]],
+            ["person", "person"],
+        ),
+    ],
+)
+def test_inference_uses_description_prompts_but_returns_public_names(labels, expected_prompts, expected_output_names):
+    model, collator = _inference_model()
+
+    results = model.inference(
+        ["Alice", "Paris"],
+        labels,
+        batch_size=1,
+        return_class_probs=True,
+    )
+
+    assert collator.entity_types == expected_prompts
+    assert [entities[0]["label"] for entities in results] == expected_output_names
+    assert [list(entities[0]["class_probs"]) for entities in results] == [[name] for name in expected_output_names]

--- a/tests/test_runtime_models.py
+++ b/tests/test_runtime_models.py
@@ -1,0 +1,552 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import torch
+import pytest
+
+import gliner.runtime.onnx as onnx_runtime
+import gliner.runtime.openvino as openvino_runtime
+from gliner.model import BaseGLiNER
+from gliner.runtime import OpenVINOModel, BaseRuntimeModel, ONNXRuntimeModel
+from gliner.modeling.outputs import GLiNERBaseOutput, GLiNERRelexOutput
+
+
+class _RuntimeModel(BaseRuntimeModel):
+    runtime_name = "fake"
+
+    def __init__(self, outputs, input_names=("input_ids", "attention_mask")):
+        super().__init__(
+            session=object(),
+            input_names=input_names,
+            output_names=outputs,
+        )
+        self.outputs = outputs
+        self.received_inputs = None
+
+    def run_inference(self, inputs):
+        self.received_inputs = inputs
+        return self.outputs
+
+
+class _ORTValueInfo:
+    def __init__(self, name):
+        self.name = name
+
+
+class _ORTSession:
+    def __init__(self, input_names, outputs, providers=None):
+        self._inputs = [_ORTValueInfo(name) for name in input_names]
+        self._outputs = [_ORTValueInfo(name) for name, _ in outputs]
+        self._output_values = [value for _, value in outputs]
+        self._providers = ["CPUExecutionProvider"] if providers is None else providers
+        self.run_args = None
+
+    def get_inputs(self):
+        return self._inputs
+
+    def get_outputs(self):
+        return self._outputs
+
+    def get_providers(self):
+        return self._providers
+
+    def run(self, requested_outputs, inputs):
+        self.run_args = (requested_outputs, inputs)
+        return self._output_values
+
+
+class _OpenVINOPort:
+    def __init__(self, name):
+        self._name = name
+
+    def get_any_name(self):
+        return self._name
+
+    def get_tensor(self):
+        return self
+
+    def set_names(self, names):
+        self._name = next(iter(names))
+
+
+class _OpenVINOCompiledModel:
+    def __init__(self, input_names, outputs):
+        self.inputs = [_OpenVINOPort(name) for name in input_names]
+        self.outputs = [_OpenVINOPort(name) for name, _ in outputs]
+        self._results = {port: value for port, (_, value) in zip(self.outputs, outputs, strict=True)}
+        self.received_inputs = None
+
+    def __call__(self, inputs):
+        self.received_inputs = inputs
+        return self._results
+
+
+class _OpenVINOCore:
+    def __init__(self, compiled_model):
+        self.compiled_model = compiled_model
+        self.read_model_arg = None
+        self.compile_args = None
+
+    def read_model(self, model_path):
+        self.read_model_arg = model_path
+        return model_path
+
+    def compile_model(self, model, device_name, config):
+        self.compile_args = (model, device_name, config)
+        return self.compiled_model
+
+
+class _OpenVINOExportAPI:
+    PartialShape = list
+
+    def __init__(self, fail_conversion=False):
+        self.fail_conversion = fail_conversion
+        self.convert_args = None
+        self.converted_model = None
+        self.save_args = None
+
+    def convert_model(self, model, example_input, input):
+        self.convert_args = (model, example_input, input)
+        if self.fail_conversion:
+            raise RuntimeError("conversion failed")
+        self.converted_model = type(
+            "ConvertedModel",
+            (),
+            {
+                "inputs": [_OpenVINOPort("") for _ in example_input],
+                "outputs": [_OpenVINOPort("")],
+            },
+        )()
+        return self.converted_model
+
+    def save_model(self, model, output_path, compress_to_fp16):
+        output_path = Path(output_path)
+        self.save_args = (model, output_path, compress_to_fp16)
+        output_path.write_text("xml", encoding="utf-8")
+        output_path.with_suffix(".bin").write_bytes(b"weights")
+
+
+class _ExportableModel:
+    export_to_openvino = BaseGLiNER.export_to_openvino
+
+    def __init__(self):
+        self.export_args = None
+        self.wrapper = object()
+        self.example_inputs = (
+            torch.ones((1, 4), dtype=torch.long),
+            torch.ones((1, 4), dtype=torch.long),
+        )
+        self.spec = {
+            "input_names": ["input_ids", "attention_mask"],
+            "output_names": ["logits"],
+            "dynamic_axes": {
+                "input_ids": {0: "batch_size", 1: "sequence_length"},
+                "attention_mask": {0: "batch_size"},
+                "logits": {0: "batch_size"},
+            },
+        }
+        self.config = type(
+            "ExportConfig",
+            (),
+            {"to_json_file": lambda _, path: Path(path).write_text("{}", encoding="utf-8")},
+        )()
+        tokenizer = type(
+            "ExportTokenizer",
+            (),
+            {"save_pretrained": lambda _, path: (Path(path) / "tokenizer.json").write_text("{}", encoding="utf-8")},
+        )()
+        self.data_processor = type("ExportProcessor", (), {"transformer_tokenizer": tokenizer})()
+
+    def _check_export_preconditions(self):
+        return None
+
+    def _prepare_export_graph(self, **export_kwargs):
+        self.export_args = export_kwargs
+        return self.wrapper, self.example_inputs, self.spec
+
+
+class _Config:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+class _Decoder:
+    def __init__(self, config):
+        self.config = config
+
+
+class _LoaderGLiNER(BaseGLiNER):
+    config_class = _Config
+    decoder_class = _Decoder
+
+    def _create_model(self, config, backbone_from_pretrained, cache_dir, **kwargs):
+        raise AssertionError("Runtime loading must inject a model adapter.")
+
+    def _create_data_processor(self, config, cache_dir, tokenizer=None, **kwargs):
+        return object()
+
+    def resize_embeddings(self):
+        return None
+
+    def inference(self):
+        return None
+
+    def evaluate(self):
+        return None
+
+
+def test_base_runtime_prepares_expected_inputs_and_ignores_extras():
+    model = _RuntimeModel({"logits": np.array([1.0], dtype=np.float32)})
+    input_ids = torch.tensor([[1, 2]], dtype=torch.long)
+    attention_mask = np.array([[1, 1]], dtype=np.int64)
+
+    with pytest.warns(UserWarning):
+        prepared = model.prepare_inputs(
+            {
+                "input_ids": input_ids,
+                "attention_mask": attention_mask,
+                "not_in_graph": torch.tensor([99]),
+            }
+        )
+
+    assert set(prepared) == {"input_ids", "attention_mask"}
+    np.testing.assert_array_equal(prepared["input_ids"], input_ids.numpy())
+    np.testing.assert_array_equal(prepared["attention_mask"], attention_mask)
+
+
+def test_base_runtime_rejects_missing_graph_inputs():
+    model = _RuntimeModel({"logits": np.array([1.0], dtype=np.float32)})
+
+    with pytest.raises(ValueError, match="attention_mask"):
+        model(input_ids=torch.tensor([[1, 2]]))
+
+
+def test_base_runtime_maps_positional_inputs_and_builds_base_output():
+    logits = np.array([[[0.25, 0.75]]], dtype=np.float32)
+    model = _RuntimeModel({"logits": logits})
+
+    output = model(
+        torch.tensor([[1, 2]], dtype=torch.long),
+        torch.tensor([[1, 1]], dtype=torch.long),
+    )
+
+    assert isinstance(output, GLiNERBaseOutput)
+    assert not isinstance(output, GLiNERRelexOutput)
+    assert output.logits is logits
+    assert set(model.received_inputs) == {"input_ids", "attention_mask"}
+
+
+def test_base_runtime_builds_relation_output_from_output_schema():
+    outputs = {
+        "logits": np.array([1.0], dtype=np.float32),
+        "rel_idx": np.array([[0, 1]], dtype=np.int64),
+        "rel_logits": np.array([0.8], dtype=np.float32),
+        "rel_mask": np.array([1], dtype=np.int64),
+    }
+    model = _RuntimeModel(outputs)
+
+    output = model(
+        input_ids=torch.tensor([[1]], dtype=torch.long),
+        attention_mask=torch.tensor([[1]], dtype=torch.long),
+    )
+
+    assert isinstance(output, GLiNERRelexOutput)
+    assert output.logits is outputs["logits"]
+    assert output.rel_idx is outputs["rel_idx"]
+    assert output.rel_logits is outputs["rel_logits"]
+    assert output.rel_mask is outputs["rel_mask"]
+
+
+def test_base_runtime_rejects_incomplete_relation_output_schema():
+    model = _RuntimeModel(
+        {
+            "logits": np.array([1.0], dtype=np.float32),
+            "rel_logits": np.array([0.8], dtype=np.float32),
+        }
+    )
+
+    with pytest.raises(ValueError, match="relation outputs are incomplete"):
+        model(
+            input_ids=torch.tensor([[1]], dtype=torch.long),
+            attention_mask=torch.tensor([[1]], dtype=torch.long),
+        )
+
+
+def test_onnx_runtime_discovers_names_and_maps_session_outputs():
+    first = np.array([10], dtype=np.int64)
+    logits = np.array([0.5], dtype=np.float32)
+    session = _ORTSession(
+        input_names=["attention_mask", "input_ids"],
+        outputs=[("first", first), ("logits", logits)],
+    )
+    model = ONNXRuntimeModel(session=session)
+    prepared = {
+        "attention_mask": np.array([[1]], dtype=np.int64),
+        "input_ids": np.array([[42]], dtype=np.int64),
+    }
+
+    outputs = model.run_inference(prepared)
+
+    assert model.runtime_name == "onnxruntime"
+    assert model.session is session
+    assert model.input_names == {"attention_mask": 0, "input_ids": 1}
+    assert model.output_names == {"first": 0, "logits": 1}
+    assert session.run_args == (None, prepared)
+    assert outputs["first"] is first
+    assert outputs["logits"] is logits
+
+
+def test_onnx_runtime_uses_effective_session_providers_for_device():
+    session = _ORTSession(
+        input_names=["input_ids"],
+        outputs=[("logits", np.array([0.5], dtype=np.float32))],
+        providers=["CUDAExecutionProvider", "CPUExecutionProvider"],
+    )
+
+    model = ONNXRuntimeModel(session=session, providers=["CPUExecutionProvider"])
+
+    assert model.device == torch.device("cuda")
+
+
+def test_openvino_runtime_maps_results_by_output_port():
+    logits = np.array([0.5], dtype=np.float32)
+    auxiliary = np.array([7], dtype=np.int64)
+    compiled_model = _OpenVINOCompiledModel(
+        input_names=["input_ids", "attention_mask"],
+        outputs=[("logits", logits), ("auxiliary", auxiliary)],
+    )
+    model = OpenVINOModel(compiled_model=compiled_model)
+    prepared = {
+        "input_ids": np.array([[42]], dtype=np.int64),
+        "attention_mask": np.array([[1]], dtype=np.int64),
+    }
+
+    outputs = model.run_inference(prepared)
+
+    assert model.runtime_name == "openvino"
+    assert model.session is compiled_model
+    assert model.input_names == {"input_ids": 0, "attention_mask": 1}
+    assert model.output_names == {"logits": 0, "auxiliary": 1}
+    assert compiled_model.received_inputs is prepared
+    assert outputs["logits"] is logits
+    assert outputs["auxiliary"] is auxiliary
+
+
+def test_openvino_runtime_passes_device_and_config_to_injected_core():
+    compiled_model = _OpenVINOCompiledModel(
+        input_names=["input_ids"],
+        outputs=[("logits", np.array([0.5], dtype=np.float32))],
+    )
+    core = _OpenVINOCore(compiled_model)
+    config = {"PERFORMANCE_HINT": "LATENCY"}
+
+    model = OpenVINOModel(
+        model_path="model.onnx",
+        device_name="AUTO",
+        config=config,
+        core=core,
+    )
+
+    assert model.session is compiled_model
+    assert core.read_model_arg == "model.onnx"
+    assert core.compile_args == ("model.onnx", "AUTO", config)
+
+
+def test_base_gliner_exports_openvino_ir_directly(monkeypatch, tmp_path):
+    api = _OpenVINOExportAPI()
+    monkeypatch.setattr(openvino_runtime, "_require_openvino", lambda: api)
+    model = _ExportableModel()
+
+    paths = model.export_to_openvino(
+        tmp_path,
+        "nested/gliner.xml",
+        compress_to_fp16=True,
+        labels=["person"],
+    )
+
+    xml_path = tmp_path / "nested" / "gliner.xml"
+    assert paths == {
+        "openvino_path": str(xml_path),
+        "weights_path": str(xml_path.with_suffix(".bin")),
+    }
+    assert model.export_args == {"labels": ["person"]}
+    assert api.convert_args == (
+        model.wrapper,
+        model.example_inputs,
+        [[-1, -1], [-1, 4]],
+    )
+    assert [port.get_any_name() for port in api.converted_model.inputs] == ["input_ids", "attention_mask"]
+    assert [port.get_any_name() for port in api.converted_model.outputs] == ["logits"]
+    assert api.save_args[1:] == (xml_path, True)
+    assert xml_path.is_file()
+    assert xml_path.with_suffix(".bin").is_file()
+    assert (tmp_path / "gliner_config.json").is_file()
+    assert (tmp_path / "tokenizer.json").is_file()
+
+
+def test_base_gliner_openvino_export_does_not_write_assets_after_conversion_failure(monkeypatch, tmp_path):
+    monkeypatch.setattr(openvino_runtime, "_require_openvino", lambda: _OpenVINOExportAPI(fail_conversion=True))
+    model = _ExportableModel()
+
+    with pytest.raises(RuntimeError, match="conversion failed"):
+        model.export_to_openvino(tmp_path)
+
+    assert not (tmp_path / "model.xml").exists()
+    assert not (tmp_path / "gliner_config.json").exists()
+    assert not (tmp_path / "tokenizer.json").exists()
+
+
+def test_base_gliner_openvino_export_validates_filename_before_loading_dependency(monkeypatch, tmp_path):
+    def unexpected_dependency_load():
+        raise AssertionError("OpenVINO must not be loaded for an invalid output name")
+
+    monkeypatch.setattr(openvino_runtime, "_require_openvino", unexpected_dependency_load)
+
+    with pytest.raises(ValueError, match=r"\.xml extension"):
+        _ExportableModel().export_to_openvino(tmp_path, "model.onnx")
+
+
+def test_base_gliner_direct_openvino_export_supports_variadic_dynamic_graph(tmp_path):
+    pytest.importorskip("openvino")
+
+    class VariadicAdd(torch.nn.Module):
+        def forward(self, *inputs):
+            return inputs[0] + inputs[1]
+
+    model = _ExportableModel()
+    model.wrapper = VariadicAdd()
+    model.spec["dynamic_axes"]["attention_mask"][1] = "sequence_length"
+    paths = model.export_to_openvino(tmp_path)
+
+    runtime = OpenVINOModel(model_path=paths["openvino_path"])
+    for width in (4, 7):
+        values = np.ones((1, width), dtype=np.int64)
+        output = runtime(input_ids=values, attention_mask=values)
+        np.testing.assert_array_equal(output.logits, values * 2)
+
+
+@pytest.mark.parametrize(
+    ("runtime", "runtime_options", "expected_class"),
+    [
+        (
+            "onnxruntime",
+            {"session": _ORTSession(["input_ids"], [("logits", np.array([0.5], dtype=np.float32))])},
+            ONNXRuntimeModel,
+        ),
+        (
+            "openvino",
+            {
+                "compiled_model": _OpenVINOCompiledModel(
+                    ["input_ids"],
+                    [("logits", np.array([0.5], dtype=np.float32))],
+                )
+            },
+            OpenVINOModel,
+        ),
+    ],
+)
+def test_base_gliner_loader_wires_runtime_adapters_without_artifact_file(
+    tmp_path,
+    runtime,
+    runtime_options,
+    expected_class,
+):
+    (tmp_path / "gliner_config.json").write_text("{}", encoding="utf-8")
+
+    model = _LoaderGLiNER.from_pretrained(
+        str(tmp_path),
+        model_dir=tmp_path,
+        load_tokenizer=False,
+        runtime=runtime,
+        runtime_options=runtime_options,
+    )
+
+    assert isinstance(model.model, expected_class)
+    assert model.runtime == runtime
+    assert model.is_runtime_model
+    assert model.onnx_model is (runtime == "onnxruntime")
+
+    with pytest.raises(RuntimeError, match=r"torch\.compile is only available"):
+        model.compile()
+
+
+def test_openvino_runtime_loads_and_executes_real_ir(tmp_path):
+    ov = pytest.importorskip("openvino")
+    input_node = ov.opset13.parameter([1, 2], np.float32, name="input_ids")
+    logits = ov.opset13.multiply(input_node, ov.opset13.constant(np.array(2.0, dtype=np.float32)))
+    logits.output(0).get_tensor().set_names({"logits"})
+    graph = ov.Model([logits], [input_node], "tiny_gliner_runtime")
+    model_path = tmp_path / "model.xml"
+    ov.save_model(graph, model_path, compress_to_fp16=False)
+
+    model = OpenVINOModel(model_path=model_path, device_name="CPU")
+    output = model(input_ids=np.array([[1.0, 3.0]], dtype=np.float32))
+
+    assert isinstance(output, GLiNERBaseOutput)
+    np.testing.assert_allclose(output.logits, np.array([[2.0, 6.0]], dtype=np.float32))
+
+
+@pytest.mark.parametrize(
+    ("module", "model_class", "dependency_name"),
+    [
+        (onnx_runtime, ONNXRuntimeModel, "onnxruntime"),
+        (openvino_runtime, OpenVINOModel, "openvino"),
+    ],
+)
+def test_runtime_loaders_report_missing_optional_dependency(monkeypatch, module, model_class, dependency_name):
+    def missing_dependency(name):
+        assert name == dependency_name
+        raise ImportError(name)
+
+    monkeypatch.setattr(module.importlib, "import_module", missing_dependency)
+
+    with pytest.raises(ImportError, match=dependency_name):
+        model_class(model_path="model.onnx")
+
+
+@pytest.mark.parametrize(
+    ("runtime", "load_onnx_model", "expected"),
+    [
+        (None, False, "torch"),
+        (None, True, "onnxruntime"),
+        ("pytorch", False, "torch"),
+        ("onnx", False, "onnxruntime"),
+        ("ORT", False, "onnxruntime"),
+        ("ov", False, "openvino"),
+        ("OpenVINO", False, "openvino"),
+    ],
+)
+def test_base_gliner_normalizes_runtime_aliases(runtime, load_onnx_model, expected):
+    assert BaseGLiNER._normalize_runtime(runtime, load_onnx_model) == expected
+
+
+def test_base_gliner_rejects_conflicting_legacy_runtime_flag():
+    with pytest.raises(ValueError, match="load_onnx_model=True conflicts"):
+        BaseGLiNER._normalize_runtime("openvino", load_onnx_model=True)
+
+
+def test_base_gliner_rejects_torch_only_options_for_external_runtime():
+    with pytest.raises(ValueError, match="dtype, quantize only apply to the PyTorch runtime"):
+        BaseGLiNER._validate_runtime_only_options(
+            "openvino",
+            variant=None,
+            dtype="fp16",
+            quantize="int8",
+            compile_torch_model=False,
+            low_cpu_mem_usage=False,
+        )
+
+
+@pytest.mark.parametrize("runtime", ["onnxruntime", "openvino"])
+@pytest.mark.parametrize(
+    "config",
+    [
+        _Config(model_type="gliner_streaming_span"),
+        _Config(labels_decoder="decoder-model"),
+    ],
+)
+def test_base_gliner_rejects_runtime_unsupported_architectures(runtime, config):
+    with pytest.raises(NotImplementedError, match="does not support"):
+        BaseGLiNER._validate_runtime_architecture(config, runtime)

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -1,5 +1,8 @@
 from unittest.mock import Mock
 
+import pytest
+
+from gliner.serve.client import GLiNERClient
 from gliner.serve.server import GLiNERServer, _min_batch_value, _normalize_relation_lists
 
 
@@ -8,6 +11,7 @@ class _FakeModel:
         self.run_batch_kwargs = None
         self.decode_batch_kwargs = None
         self.prepared_labels = None
+        self.collated_label_names = None
 
     def prepare_batch(self, texts, labels):
         self.prepared_labels = labels
@@ -16,6 +20,7 @@ class _FakeModel:
         return {
             "input_x": [{"tokenized_text": text.split(), "ner": None} for text in valid_texts],
             "entity_types": labels,
+            "label_names": labels,
             "valid_texts": valid_texts,
             "valid_to_orig_idx": valid_to_orig_idx,
             "start_token_map": [[0] for _ in valid_texts],
@@ -23,7 +28,8 @@ class _FakeModel:
             "num_original": len(texts),
         }
 
-    def collate_batch(self, input_x, entity_types, collator):
+    def collate_batch(self, input_x, entity_types, collator, label_names=None):
+        self.collated_label_names = label_names
         return {"input_x": input_x, "entity_types": entity_types}
 
     def run_batch(self, batch, **kwargs):
@@ -34,7 +40,9 @@ class _FakeModel:
         self.decode_batch_kwargs = kwargs
         return [[object()] for _ in batch["input_x"]]
 
-    def map_entities_to_text(self, decoded, valid_texts, valid_to_orig_idx, start_token_map, end_token_map, num_original):
+    def map_entities_to_text(
+        self, decoded, valid_texts, valid_to_orig_idx, start_token_map, end_token_map, num_original
+    ):
         results = [[] for _ in range(num_original)]
         for decoded_idx, original_idx in enumerate(valid_to_orig_idx):
             results[original_idx] = decoded[decoded_idx]
@@ -66,6 +74,21 @@ def test_observed_seq_len_uses_largest_per_request_prompt():
     assert observed == 11
 
 
+def test_observed_seq_len_uses_dictionary_descriptions():
+    server = GLiNERServer.__new__(GLiNERServer)
+    server.config = Mock(calibration_min_seq_len=1, max_model_len=512)
+
+    observed = server.observed_seq_len(
+        ["short text", "longer text here"],
+        labels=[
+            {"person": "a human individual"},
+            {"org": "a company or other organization", "place": "a geographical place"},
+        ],
+    )
+
+    assert observed == 11
+
+
 def test_filter_labels_truncates_per_request_label_lists():
     server = GLiNERServer.__new__(GLiNERServer)
     server.config = Mock(max_labels=2)
@@ -78,6 +101,21 @@ def test_filter_labels_truncates_per_request_label_lists():
     ) == [
         ["person", "organization"],
         ["date"],
+    ]
+
+
+def test_filter_labels_truncates_dictionary_labels_without_losing_descriptions():
+    server = GLiNERServer.__new__(GLiNERServer)
+    server.config = Mock(max_labels=1)
+
+    assert server._filter_labels(
+        [
+            {"person": "a human individual", "organization": "a company"},
+            {"location": "a geographical place", "date": "a calendar date"},
+        ]
+    ) == [
+        {"person": "a human individual"},
+        {"location": "a geographical place"},
     ]
 
 
@@ -98,6 +136,7 @@ def test_run_batch_ner_passes_heterogeneous_decode_controls():
 
     assert len(result) == 2
     assert server.model.prepared_labels == [["person", "organization"], ["location"]]
+    assert server.model.collated_label_names == [["person", "organization"], ["location"]]
     assert server.model.run_batch_kwargs["threshold"] == 0.2
     assert server.model.decode_batch_kwargs["threshold"] == [0.2, 0.8]
     assert server.model.decode_batch_kwargs["flat_ner"] == [True, False]
@@ -129,3 +168,65 @@ def test_run_batch_ner_passes_valid_text_adapter_ids():
 
     assert len(result) == 2
     assert server.model.run_batch_kwargs["adapter_ids"] == ["__base__"]
+
+
+def test_client_sends_one_dictionary_label_set_per_text():
+    client = GLiNERClient()
+    client._post = lambda payload: payload
+
+    results = client.predict(
+        ["John works at Acme", "Paris is sunny"],
+        labels=[
+            {"person": "a human individual", "organization": "a company"},
+            {"location": "a geographical place"},
+        ],
+    )
+
+    assert [result["labels"] for result in results] == [
+        {"person": "a human individual", "organization": "a company"},
+        {"location": "a geographical place"},
+    ]
+
+
+def test_client_reuses_shared_dictionary_labels_for_each_text():
+    client = GLiNERClient()
+    client._post = lambda payload: payload
+    labels = {"person": "a human individual"}
+
+    results = client.predict(["John", "Jane"], labels=labels)
+
+    assert [result["labels"] for result in results] == [labels, labels]
+
+
+def test_client_rejects_wrong_number_of_per_text_label_sets():
+    client = GLiNERClient()
+
+    with pytest.raises(ValueError, match="Per-text labels must have length 2, got 1"):
+        client.predict(["John", "Paris"], labels=[{"person": "a human individual"}])
+
+
+def test_runtime_server_splits_per_text_labels_into_singleton_batches():
+    server = GLiNERServer.__new__(GLiNERServer)
+    server.model = Mock(is_runtime_model=True)
+    server._supports_relations = False
+    calls = []
+
+    def run_batch(texts, labels, threshold, flat_ner, multi_label, adapter_ids):
+        calls.append((texts, labels, threshold))
+        return [[{"label": next(iter(labels))}]]
+
+    server._run_batch_ner = run_batch
+    results = server._run_batch_internal(
+        ["Alice", "Paris"],
+        [
+            {"person": "a human individual"},
+            {"location": "a geographical place"},
+        ],
+        threshold=[0.4, 0.6],
+    )
+
+    assert calls == [
+        (["Alice"], {"person": "a human individual"}, 0.4),
+        (["Paris"], {"location": "a geographical place"}, 0.6),
+    ]
+    assert results == [[{"label": "person"}], [{"label": "location"}]]

--- a/tests/test_vector_outputs.py
+++ b/tests/test_vector_outputs.py
@@ -1,0 +1,522 @@
+import pickle
+from types import SimpleNamespace
+
+import numpy as np
+import torch
+import pytest
+
+from gliner.model import (
+    BaseEncoderGLiNER,
+    BaseBiEncoderGLiNER,
+    StreamingSpanGLiNER,
+    UniEncoderSpanRelexGLiNER,
+    UniEncoderTokenDecoderGLiNER,
+    _attach_entity_vectors,
+    _attach_relation_vectors,
+)
+from gliner.modeling.base import UniEncoderTokenDecoderModel
+from gliner.decoding.decoder import (
+    Span,
+    SpanDecoder,
+    TokenDecoder,
+    DecodedRelation,
+    SpanRelexDecoder,
+    TokenGenerativeDecoder,
+)
+from gliner.modeling.outputs import GLiNERBaseOutput
+
+
+def test_span_decoder_preserves_flat_span_and_class_indices():
+    decoder = SpanDecoder(SimpleNamespace(max_width=2))
+    logits = torch.full((1, 2, 2, 2), -10.0)
+    logits[0, 1, 0, 1] = 10.0
+
+    decoded = decoder.decode(
+        tokens=[["zero", "one"]],
+        id_to_classes={1: "first", 2: "second"},
+        model_output=logits,
+        threshold=0.5,
+    )
+
+    assert len(decoded[0]) == 1
+    span = decoded[0][0]
+    assert (span.start, span.end, span.entity_type) == (1, 1, "second")
+    assert span.class_index == 1
+    assert span.span_index == 2  # start * max_width + zero-based width
+
+
+def test_token_decoder_preserves_class_index_without_inventing_a_span_index():
+    decoder = TokenDecoder(SimpleNamespace())
+    logits = torch.full((1, 3, 2, 3), -10.0)
+    logits[0, 0, 1, 0] = 10.0  # start, class index 1
+    logits[0, 0, 1, 2] = 10.0  # inside
+    logits[0, 1, 1, 2] = 10.0  # inside
+    logits[0, 1, 1, 1] = 10.0  # end
+
+    decoded = decoder.decode(
+        tokens=[["New", "York", "today"]],
+        id_to_classes={1: "person", 2: "location"},
+        model_output=logits,
+        threshold=0.5,
+    )
+
+    assert len(decoded[0]) == 1
+    span = decoded[0][0]
+    assert (span.start, span.end, span.entity_type) == (0, 1, "location")
+    assert span.class_index == 1
+    assert span.span_index is None
+
+
+def test_span_relex_decoder_preserves_relation_pair_and_class_indices():
+    decoder = SpanRelexDecoder(SimpleNamespace(max_width=1))
+    entity_logits = torch.full((1, 2, 1, 1), -10.0)
+    entity_logits[0, 0, 0, 0] = 10.0
+    entity_logits[0, 1, 0, 0] = 10.0
+    relation_logits = torch.full((1, 2, 2), -10.0)
+    relation_logits[0, 1, 1] = 10.0
+
+    spans, relations = decoder.decode(
+        tokens=[["Alice", "Acme"]],
+        id_to_classes={1: "entity"},
+        model_output=entity_logits,
+        rel_idx=torch.tensor([[[0, 1], [1, 0]]]),
+        rel_logits=relation_logits,
+        rel_mask=torch.tensor([[True, True]]),
+        rel_id_to_classes={1: "first relation", 2: "second relation"},
+        threshold=0.5,
+        relation_threshold=0.5,
+    )
+
+    assert len(spans[0]) == 2
+    assert len(relations[0]) == 1
+    relation = relations[0][0]
+    assert isinstance(relation, DecodedRelation)
+    assert tuple(relation)[:3] == (1, "second relation", 0)
+    assert relation.pair_index == 1
+    assert relation.class_index == 1
+
+
+def test_base_output_omits_span_embeddings_by_default_and_exposes_them_when_requested():
+    default_output = GLiNERBaseOutput(logits=torch.zeros(1))
+
+    assert default_output.span_embeddings is None
+    assert "span_embeddings" not in default_output
+
+    span_embeddings = torch.ones(1, 2, 3)
+    enriched_output = GLiNERBaseOutput(logits=torch.zeros(1), span_embeddings=span_embeddings)
+
+    assert enriched_output.span_embeddings is span_embeddings
+    assert enriched_output["span_embeddings"] is span_embeddings
+
+
+def test_span_vectors_gather_exact_native_rows_and_convert_to_float32():
+    span_embeddings = torch.arange(24, dtype=torch.float64).reshape(1, 2, 3, 4)
+    decoded = [
+        [
+            Span(
+                start=1,
+                end=2,
+                entity_type="organization",
+                score=0.9,
+                class_index=1,
+                span_index=4,
+            )
+        ]
+    ]
+
+    _attach_entity_vectors(
+        decoded,
+        SimpleNamespace(span_embeddings=span_embeddings),
+        SimpleNamespace(span_mode="span_level"),
+        return_vectors=True,
+        return_label_vectors=False,
+    )
+
+    vector = decoded[0][0].vector
+    np.testing.assert_array_equal(vector, span_embeddings.flatten(1, 2)[0, 4].numpy())
+    assert vector.dtype == np.float32
+    assert decoded[0][0].label_vector is None
+
+
+def test_token_vectors_average_inclusive_word_ranges_and_select_each_class_index():
+    words_embedding = torch.tensor(
+        [[[-3.0, 1.0], [1.0, 5.0], [8.0, 11.0]]],
+        dtype=torch.float64,
+    )
+    prompts_embedding = torch.tensor(
+        [[[10.0, 11.0], [20.0, 21.0], [30.0, 31.0]]],
+        dtype=torch.float64,
+    )
+    first = Span(0, 1, "first", 0.9, class_index=0)
+    second = Span(2, 2, "third", 0.8, class_index=2)
+
+    _attach_entity_vectors(
+        [[first, second]],
+        SimpleNamespace(
+            words_embedding=words_embedding,
+            prompts_embedding=prompts_embedding,
+        ),
+        SimpleNamespace(span_mode="token_level"),
+        return_vectors=True,
+        return_label_vectors=True,
+    )
+
+    # Span ends are inclusive: positions 0 and 1 both contribute to the first mean.
+    np.testing.assert_array_equal(first.vector, np.array([-1.0, 3.0], dtype=np.float32))
+    np.testing.assert_array_equal(second.vector, np.array([8.0, 11.0], dtype=np.float32))
+    np.testing.assert_array_equal(first.label_vector, np.array([10.0, 11.0], dtype=np.float32))
+    np.testing.assert_array_equal(second.label_vector, np.array([30.0, 31.0], dtype=np.float32))
+    assert first.vector.dtype == first.label_vector.dtype == np.float32
+
+
+def test_label_vectors_can_be_requested_without_span_vectors():
+    first = Span(0, 0, "public name one", 0.9, class_index=0, span_index=0)
+    second = Span(0, 0, "public name two", 0.8, class_index=1, span_index=0)
+    prompts_embedding = torch.tensor([[[1.0, 2.0], [7.0, 8.0]]])
+
+    _attach_entity_vectors(
+        [[first, second]],
+        SimpleNamespace(prompts_embedding=prompts_embedding),
+        SimpleNamespace(span_mode="span_level"),
+        return_vectors=False,
+        return_label_vectors=True,
+    )
+
+    assert first.vector is None
+    assert second.vector is None
+    np.testing.assert_array_equal(first.label_vector, np.array([1.0, 2.0], dtype=np.float32))
+    np.testing.assert_array_equal(second.label_vector, np.array([7.0, 8.0], dtype=np.float32))
+
+
+def test_entity_mapper_only_includes_vector_keys_when_attached():
+    vector = np.array([1.0, 2.0], dtype=np.float32)
+    label_vector = np.array([3.0, 4.0], dtype=np.float32)
+    plain = Span(0, 0, "person", 0.9)
+    enriched = Span(1, 1, "organization", 0.8, vector=vector, label_vector=label_vector)
+
+    mapped = BaseEncoderGLiNER._map_entities_to_original(
+        None,
+        [[plain, enriched]],
+        [0],
+        [[0, 6]],
+        [[5, 10]],
+        ["Alice Acme"],
+        1,
+    )[0]
+
+    assert "vector" not in mapped[0]
+    assert "label_vector" not in mapped[0]
+    assert mapped[1]["vector"] is vector
+    assert mapped[1]["label_vector"] is label_vector
+
+
+def test_pair_relation_vectors_and_labels_are_selected_independently():
+    first = DecodedRelation(0, "works for", 1, 0.9, pair_index=1, class_index=0)
+    second = DecodedRelation(1, "located in", 0, 0.8, pair_index=0, class_index=1)
+    relation_embeddings = torch.tensor(
+        [[[1.0, 2.0], [5.0, 6.0]]],
+        dtype=torch.float64,
+    )
+    rel_prompts_embedding = torch.tensor(
+        [[[11.0, 12.0], [21.0, 22.0]]],
+        dtype=torch.float64,
+    )
+
+    _attach_relation_vectors(
+        [[first, second]],
+        SimpleNamespace(
+            relation_embeddings=relation_embeddings,
+            rel_prompts_embedding=rel_prompts_embedding,
+        ),
+        return_vectors=True,
+        return_label_vectors=True,
+    )
+
+    np.testing.assert_array_equal(first.vector, np.array([5.0, 6.0], dtype=np.float32))
+    np.testing.assert_array_equal(second.vector, np.array([1.0, 2.0], dtype=np.float32))
+    np.testing.assert_array_equal(first.label_vector, np.array([11.0, 12.0], dtype=np.float32))
+    np.testing.assert_array_equal(second.label_vector, np.array([21.0, 22.0], dtype=np.float32))
+    assert first.vector.dtype == first.label_vector.dtype == np.float32
+    assert first.head_relation_vector is None
+    assert first.tail_relation_vector is None
+
+
+def test_triple_relation_vectors_attach_separate_head_and_tail_rows():
+    relation = DecodedRelation(0, "works for", 1, 0.9, pair_index=1, class_index=0)
+    head_embeddings = torch.tensor([[[1.0, 2.0], [3.0, 4.0]]], dtype=torch.float64)
+    tail_embeddings = torch.tensor([[[5.0, 6.0], [7.0, 8.0]]], dtype=torch.float64)
+
+    _attach_relation_vectors(
+        [[relation]],
+        SimpleNamespace(
+            relation_head_embeddings=head_embeddings,
+            relation_tail_embeddings=tail_embeddings,
+        ),
+        return_vectors=True,
+        return_label_vectors=False,
+    )
+
+    assert relation.vector is None
+    assert relation.label_vector is None
+    np.testing.assert_array_equal(
+        relation.head_relation_vector,
+        np.array([3.0, 4.0], dtype=np.float32),
+    )
+    np.testing.assert_array_equal(
+        relation.tail_relation_vector,
+        np.array([7.0, 8.0], dtype=np.float32),
+    )
+    assert relation.head_relation_vector.dtype == relation.tail_relation_vector.dtype == np.float32
+
+
+def test_relation_mapper_preserves_pair_and_triple_vectors_and_omits_missing_keys():
+    entities = [[Span(0, 0, "person", 0.9), Span(1, 1, "organization", 0.8)]]
+    pair = DecodedRelation(
+        0,
+        "works for",
+        1,
+        0.7,
+        vector=np.array([1.0], dtype=np.float32),
+        label_vector=np.array([2.0], dtype=np.float32),
+    )
+    triple = DecodedRelation(
+        1,
+        "employs",
+        0,
+        0.6,
+        head_relation_vector=np.array([3.0], dtype=np.float32),
+        tail_relation_vector=np.array([4.0], dtype=np.float32),
+    )
+    plain = DecodedRelation(0, "knows", 1, 0.5)
+
+    mapped = UniEncoderSpanRelexGLiNER._process_relations(
+        None,
+        [[pair, triple, plain]],
+        entities,
+        [[0, 6]],
+        [[5, 10]],
+        ["Alice Acme"],
+    )[0]
+
+    assert mapped[0]["vector"] is pair.vector
+    assert mapped[0]["label_vector"] is pair.label_vector
+    assert "head_relation_vector" not in mapped[0]
+    assert "tail_relation_vector" not in mapped[0]
+
+    assert mapped[1]["head_relation_vector"] is triple.head_relation_vector
+    assert mapped[1]["tail_relation_vector"] is triple.tail_relation_vector
+    assert "vector" not in mapped[1]
+    assert "label_vector" not in mapped[1]
+
+    for key in ("vector", "label_vector", "head_relation_vector", "tail_relation_vector"):
+        assert key not in mapped[2]
+
+
+def test_decoded_relation_keeps_legacy_tuple_payload_and_metadata_when_pickled():
+    relation = DecodedRelation(
+        2,
+        "parent of",
+        4,
+        0.75,
+        pair_index=6,
+        class_index=3,
+        vector=np.array([1.0, 2.0], dtype=np.float32),
+    )
+
+    assert tuple(relation) == (2, "parent of", 4, 0.75)
+    assert len(relation) == 4
+    assert (relation.head_idx, relation.label, relation.tail_idx, relation.score) == tuple(relation)
+    assert relation.pair_index == 6
+    assert relation.class_index == 3
+
+    restored = pickle.loads(pickle.dumps(relation))
+    assert tuple(restored) == tuple(relation)
+    assert restored.pair_index == relation.pair_index
+    assert restored.class_index == relation.class_index
+    np.testing.assert_array_equal(restored.vector, relation.vector)
+
+
+def test_span_internal_vector_metadata_does_not_change_legacy_equality_or_repr():
+    plain = Span(0, 1, "location", 0.9)
+    enriched = Span(
+        0,
+        1,
+        "location",
+        0.9,
+        class_index=2,
+        span_index=4,
+        vector=np.array([1.0, 2.0], dtype=np.float32),
+        label_vector=np.array([3.0, 4.0], dtype=np.float32),
+    )
+
+    assert enriched == plain
+    assert repr(enriched) == repr(plain)
+
+
+def test_encoder_inference_propagates_vector_flags_to_batch_processing():
+    model = BaseEncoderGLiNER.__new__(BaseEncoderGLiNER)
+    torch.nn.Module.__init__(model)
+    model.runtime_model = False
+    model._inference_packing_config = None
+    prepared = {
+        "input_x": [{"row": 0}],
+        "entity_types": ["person"],
+        "label_names": ["person"],
+        "valid_texts": ["Alice"],
+        "valid_to_orig_idx": [0],
+        "start_token_map": [[0]],
+        "end_token_map": [[5]],
+        "word_input_spans": None,
+        "num_original": 1,
+    }
+    observed = {}
+
+    model.prepare_batch = lambda *args, **kwargs: prepared
+    model.create_collator = object
+    model.collate_batch = lambda *args, **kwargs: {"tokens": [["Alice"]], "id_to_classes": {1: "person"}}
+
+    def process_batches(data_loader, *args, **kwargs):
+        list(data_loader)
+        observed.update(kwargs)
+        return [[]]
+
+    model._process_batches = process_batches
+    model.map_entities_to_text = lambda decoded, *args: decoded
+
+    assert model.inference(
+        ["Alice"],
+        ["person"],
+        return_vectors=True,
+        return_label_vectors=True,
+    ) == [[]]
+    assert observed["return_vectors"] is True
+    assert observed["return_label_vectors"] is True
+
+
+def test_relex_predict_relations_propagates_vector_flags_to_inference():
+    model = UniEncoderSpanRelexGLiNER.__new__(UniEncoderSpanRelexGLiNER)
+    torch.nn.Module.__init__(model)
+    observed = {}
+
+    def inference(*args, **kwargs):
+        observed.update(kwargs)
+        return [[{"label": "person"}]], [[{"relation": "works for"}]]
+
+    model.inference = inference
+
+    entities, relations = model.predict_relations(
+        "Alice Acme",
+        ["person", "organization"],
+        ["works for"],
+        return_vectors=True,
+        return_label_vectors=True,
+    )
+
+    assert entities == [{"label": "person"}]
+    assert relations == [{"relation": "works for"}]
+    assert observed["return_relations"] is True
+    assert observed["return_vectors"] is True
+    assert observed["return_label_vectors"] is True
+
+
+def test_bi_encoder_cached_inference_uses_native_embedding_argument():
+    model = BaseBiEncoderGLiNER.__new__(BaseBiEncoderGLiNER)
+    torch.nn.Module.__init__(model)
+    model.runtime_model = False
+    observed = {}
+
+    def inference(*args, **kwargs):
+        observed.update(kwargs)
+        return [[]]
+
+    model.inference = inference
+    embeddings = torch.randn(2, 4)
+
+    assert model.batch_predict_with_embeds(
+        ["Alice"],
+        embeddings,
+        ["person", "organization"],
+        return_label_vectors=True,
+    ) == [[]]
+    assert observed["labels_embeds"] is embeddings
+    assert "labels_embeddings" not in observed
+    assert observed["return_label_vectors"] is True
+
+
+def test_token_generative_decode_returns_mean_pooled_and_label_vectors():
+    config = SimpleNamespace(
+        span_mode="token_level",
+        labels_decoder="enabled",
+        decoder_mode="span",
+    )
+    model = UniEncoderTokenDecoderGLiNER.__new__(UniEncoderTokenDecoderGLiNER)
+    torch.nn.Module.__init__(model)
+    model.config = config
+    model.decoder = TokenGenerativeDecoder(config)
+    output = SimpleNamespace(
+        logits=torch.zeros(1, 2, 1, 3),
+        gen_labels=["generated label"],
+        decoder_span_idx=torch.tensor([[0]]),
+        num_gen_sequences=1,
+        span_logits=torch.tensor([[[10.0], [-10.0]]]),
+        span_idx=torch.tensor([[[0, 1], [1, 1]]]),
+        span_mask=torch.tensor([[True, True]]),
+        words_embedding=torch.tensor([[[1.0, 3.0], [5.0, 7.0]]]),
+        prompts_embedding=torch.tensor([[[11.0, 13.0]]]),
+        span_embeddings=None,
+    )
+
+    decoded = model.decode_batch(
+        output,
+        {"tokens": [["New", "York"]], "id_to_classes": {1: "location"}},
+        return_vectors=True,
+        return_label_vectors=True,
+    )
+
+    assert len(decoded[0]) == 1
+    span = decoded[0][0]
+    assert (span.start, span.end, span.generated_labels) == (0, 1, ["generated label"])
+    np.testing.assert_array_equal(span.vector, np.array([3.0, 5.0], dtype=np.float32))
+    np.testing.assert_array_equal(span.label_vector, np.array([11.0, 13.0], dtype=np.float32))
+
+
+def test_token_generative_span_selection_uses_the_boolean_span_mask():
+    model = UniEncoderTokenDecoderModel.__new__(UniEncoderTokenDecoderModel)
+    torch.nn.Module.__init__(model)
+    model.config = SimpleNamespace(decoder_mode="span")
+
+    selected, selected_mask, selected_indices = model.select_token_decoder_embedding(
+        prompts_embedding=torch.zeros(1, 1, 2),
+        prompts_embedding_mask=torch.ones(1, 1),
+        span_logits=torch.tensor([[[10.0], [-10.0]]]),
+        span_rep=torch.tensor([[[1.0, 2.0], [3.0, 4.0]]]),
+        span_idx=torch.tensor([[[0, 0], [1, 1]]]),
+        span_mask=torch.tensor([[True, True]]),
+    )
+
+    assert selected.shape == (1, 2, 1, 2)
+    assert selected_mask.squeeze(-1).tolist() == [[1, 0]]
+    assert selected_indices.tolist() == [[0, -1]]
+
+
+@pytest.mark.parametrize("flag", ["return_vectors", "return_label_vectors"])
+def test_runtime_inference_rejects_unexported_vector_outputs(flag):
+    model = BaseEncoderGLiNER.__new__(BaseEncoderGLiNER)
+    torch.nn.Module.__init__(model)
+    model.runtime_model = True
+
+    with pytest.raises(NotImplementedError, match="ONNX/OpenVINO"):
+        model.inference(["Alice"], ["person"], **{flag: True})
+
+
+def test_stateful_streaming_rejects_vector_outputs_before_mutating_a_session():
+    model = StreamingSpanGLiNER.__new__(StreamingSpanGLiNER)
+    torch.nn.Module.__init__(model)
+
+    with pytest.raises(NotImplementedError, match="stateful streaming"):
+        model.inference(
+            ["Alice"],
+            ["person"],
+            session_id=["session-1"],
+            return_vectors=True,
+        )


### PR DESCRIPTION
### Add dictionary-based label descriptions

Adds support for Dict[str, str] labels in inference and serving. Dictionary values are used as model prompts, while keys are returned in predictions. Per-text label sets are also supported.

```python3
  labels = {
      "person": "A human individual",
      "organization": "A company or institution",
  }

  entities, relations = model.inference(
      texts=["Alice works at Acme"],
      labels=labels,
  )
```

Also supports:
```
  labels = [
      {"person": "A human individual"},
      {"location": "A geographical place"},
  ]
```